### PR TITLE
Modifying where we formerly had dash2-config to dryad-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ At the same level as the `dashv2` directory:
   git clone https://github.com/CDLUC3/stash.git
   ```
 
-- Clone the [dash2-config](https://github.com/cdlib/dash2-config/) repository
+- Clone the [dryad-config](https://github.com/cdlib/dryad-config/) repository
   (private to CDL developers):
 
   ```
-  git clone git@github.com:cdlib/dash2-config.git
+  git clone git@github.com:cdlib/dryad-config.git
   ```
 
-- Symlink configuration files from `dash2-config` into the `dashv2`
+- Symlink configuration files from `dryad-config` into the `dashv2`
   `config` directory:
 
   ```

--- a/symlink_config.sh
+++ b/symlink_config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mydir="../dash2-config"
+mydir="../dryad-config"
 len=$((${#mydir} + 1))
 CURRENTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
I'm renaming dash2-config to dryad-config where needed to pull in a different copy of the config repository.