### PR TITLE
Update repository names for new GitHub structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
 
 ## Introduction
 
-**Dash** is the [UC Curation Center](http://www.cdlib.org/uc3/)'s
-implementation of the [Stash](https://github.com/CDLUC3/stash) application
+**Dryad** is the [UC Curation Center](http://www.cdlib.org/uc3/)'s
+implementation of the [Stash](https://github.com/CDL-Dryad/stash) application
 framework for research data publication and preservation, based on the
 [DataCite Metadata Schema](https://schema.datacite.org/) and the University
 of California’s [Merritt](https://merritt.cdlib.org/) repository service.
 
-- [About Dash](app/views/layouts/_about.html.md)
+- [About Dryad](app/views/layouts/_about.html.md)
 
 ## Development
 
 ### Installation
 
 See
-[Dash2 Installation](https://github.com/CDLUC3/dashv2/blob/master/documentation/dash2_install.md)
+[Dryad Installation](https://github.com/CDL-Dryad/dryad/blob/master/documentation/dryad_install.md)
 for installation notes.
 
 ### Quick Cheat Sheet
@@ -26,10 +26,10 @@ for installation notes.
 
 At the same level as the `dashv2` directory:
 
-- Clone the [Stash](https://github.com/CDLUC3/stash) repository (public):
+- Clone the [Stash](https://github.com/CDL-Dryad/stash) repository (public):
 
   ```
-  git clone https://github.com/CDLUC3/stash.git
+  git clone https://github.com/CDL-Dryad/stash.git
   ```
 
 - Clone the [dryad-config](https://github.com/cdlib/dryad-config/) repository
@@ -39,7 +39,7 @@ At the same level as the `dashv2` directory:
   git clone git@github.com:cdlib/dryad-config.git
   ```
 
-- Symlink configuration files from `dryad-config` into the `dashv2`
+- Symlink configuration files from `dryad-config` into the `dryad`
   `config` directory:
 
   ```
@@ -48,7 +48,7 @@ At the same level as the `dashv2` directory:
 
 #### Running integration/feature tests locally
 
-In the `dashv2` directory:
+In the `dryad` directory:
 
 - run `travis-prep.sh`
 - run `bundle exec rake`

--- a/app/views/layouts/_about.html.md
+++ b/app/views/layouts/_about.html.md
@@ -15,12 +15,12 @@ There are currently ten live instances of Dash:
 - [UC Press](https://dash.ucpress.edu/)
 - [ONEshare](https://oneshare.cdlib.org/) (in partnership with [DataONE](http://dataone.org/))
 
-For information about Submission to Dash check out our [guidance here](https://github.com/CDLUC3/dashv2/blob/master/app/views/layouts/_help.html.md)
+For information about Submission to Dryad check out our [guidance here](https://github.com/CDL-Dryad/dryad/blob/master/app/views/layouts/_help.html.md)
 
 
 ## Architecture and Implementation
 
-Dash is completely open source.  Our code is made publicly available on GitHub (http://cdluc3.github.io/dash/).  Dash is based on an underlying Ruby-on-Rails data publication platform called Stash. Stash encompasses three main functional components: Store, Harvest, and Share.
+Dryad is completely open source.  Our code is made publicly available on GitHub (http://cdluc3.github.io/dash/). Dryad is based on an underlying Ruby-on-Rails data publication platform called Stash. Stash encompasses three main functional components: Store, Harvest, and Share.
 
 - Store: The Store component is responsible for the selection of datasets; their description in terms of configurable metadata schemas, including specification of ORCID and Fundref identifiers for researcher and funder disambiguation; the assignment of DOIs for stable citation and retrieval; designation of an optional limited time embargo; and packaging and submission to the integrated repository
 - Harvest: The Harvest component is responsible for retrieval of descriptive metadata from that repository for inclusion into a Solr search index

--- a/app/views/layouts/_help.html.md
+++ b/app/views/layouts/_help.html.md
@@ -6,7 +6,7 @@ We have some general reminders and suggestions for publishing your data with Das
 - It is your responsibility to ensure your data are being shared responsibly and ethically. Please be careful of sharing sensitive data and ensure you are complying with institutional and governmental regulations
 - When preparing your complete version of a dataset, remember to collate all relevant explantory documents and metadata. This includes relevant documentation necessary for the re-use and replication of your dataset (e.g., readme.txt files, formal metadata records, or other critical information, etc.)
 
-Dash has a REST API that allows for download and submission of data. Check out our [documentation](https://dash.ucop.edu/api/docs/index.html) as well as our [How-To Guide](https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md)
+Dash has a REST API that allows for download and submission of data. Check out our [documentation](https://dash.ucop.edu/api/docs/index.html) as well as our [How-To Guide](https://github.com/CDL-Dryad/dryad/blob/master/stash_api/basic_submission.md)
 
 
 ## Metadata

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '3.4.1'
 
 set :application, 'dashv2'
-set :repo_url, 'https://github.com/CDLUC3/dashv2.git'
+set :repo_url, 'https://github.com/CDL-Dryad/dryad.git'
 
 # Default branch is :master -- uncomment this to prompt for branch name
 ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp unless ENV['BRANCH']
@@ -105,7 +105,7 @@ namespace :deploy do
   task :clone_engines do
     on roles(:app) do
       unless test("[ -d #{deploy_to}/releases/stash ]")
-        execute "cd #{deploy_to}/releases; git clone https://github.com/CDLUC3/stash.git"
+        execute "cd #{deploy_to}/releases; git clone https://github.com/CDL-Dryad/dryad.git"
       end
     end
   end

--- a/documentation/documentation_dump.md
+++ b/documentation/documentation_dump.md
@@ -1,12 +1,12 @@
-# Dash Technical Introductory Notes/Documentation Dump
+# Dryad Technical Introductory Notes/Documentation Dump
 
-## Demo Instance of Dash
+## Demo Instance of Dryad
 
-Our demo instance of Dash is available at [https://dashdemo.ucop.edu](https://dashdemo.ucop.edu) (available 7am-7pm Pacific time) and you may submit and test freely.
+Our demo instance of Dryad is available at [https://dashdemo.ucop.edu](https://dashdemo.ucop.edu) (available 7am-7pm Pacific time) and you may submit and test freely.
 
 ## Github Repositories & Similar
 
-* The main application for Dash is at [https://github.com/cdluc3/dashv2](https://github.com/cdluc3/dashv2) with minor customizations and configuration for an installation.  The bulk of the code lives in the stash repository.
+* The main application for Dryad is at [https://github.com/CDL-Dryad/dryad](https://github.com/CDL-Dryad/dryad) with minor customizations and configuration for an installation.  The bulk of the code lives in the stash repository.
 
 * The repository at [https://github.com/CDLUC3/stash](https://github.com/CDLUC3/stash) holds most of our code.
 
@@ -18,21 +18,19 @@ Our demo instance of Dash is available at [https://dashdemo.ucop.edu](https://da
 
     * The repository contains some other libraries/gems for things such as sword or harvesting.
 
-* We have a repository at [https://github.com/cdlib/dash2-config](https://github.com/cdlib/dash2-config) which is private.  We can re-derive some example configs from this (since our example is out of date) or give trusted others access to this repo so long as they keep any sensitive information here private.
+* We have a repository at [https://github.com/cdlib/dryad-config](https://github.com/cdlib/dryad-config) which is private.  We can re-derive some example configs from this (since our example is out of date) or give trusted others access to this repo so long as they keep any sensitive information here private.
 
-* The following repositories are used by or related to more minor aspects of the Dash service under the  CDLUC3 workspace on github:  dash2-harvester, datacite-mapping, resync-client, dash2-migrator
+* The following repositories are used by or related to more minor aspects of the Dryad service under the  CDLUC3 workspace on github:  dash2-harvester, datacite-mapping, resync-client, dash2-migrator
 
-* Travis.ci continuous integration builds for many of the Dash subcomponents are available at [https://travis-ci.org/CDLUC3](https://travis-ci.org/CDLUC3) .
+* Travis.ci continuous integration builds for many of the Dryad subcomponents are available at [https://travis-ci.org/CDLUC3](https://travis-ci.org/CDLUC3) .
 
 * We need to come up with contribution guidelines such as [Contribution Guidelines for DMPTool](https://github.com/DMPRoadmap/roadmap/blob/development/CONTRIBUTING.md), more to come soon.  # TODO
 
 ## Documentation
 
-* We have an [installation guide](dash2_install.md) for installing the user-interface part of Dash along with some of the basic depedencies.  Sorry, this is a bit out of date and probably needs to be updated but much of the information is still useful.
+* We have an [installation guide](dryad_install.md) for installing the user-interface part of Dryad along with some of the basic depedencies.
 
-* A basic generalized introduction to Dash is available at [https://dash.ucop.edu/stash/about](https://dash.ucop.edu/stash/about) .
-
-* Operations information (private) [https://confluence.ucop.edu/display/UC3/Stash+Operations](https://confluence.ucop.edu/display/UC3/Stash+Operations) 
+* A basic generalized introduction to Dryad's Dash is available at [https://dash.ucop.edu/stash/about](https://dash.ucop.edu/stash/about) .
 
 * API documentation: [https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md](https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md) and [https://dash.ucop.edu/api/docs/](https://dash.ucop.edu/api/docs/) 
 
@@ -44,7 +42,7 @@ Our demo instance of Dash is available at [https://dashdemo.ucop.edu](https://da
 
 * [Dataset submission flow](submission_flow.md), one of our longest and more complicated flows.  (Login is also somewhat complicated, but people don’t spend a lot of time doing it.)
 
-* The UI Library from the UX team and how to integrate CSS and major UI changes into the Dash application.  [https://github.com/CDLUC3/stash/blob/master/stash_engine/ui-library/README.md](https://github.com/CDLUC3/stash/blob/master/stash_engine/ui-library/README.md)
+* The UI Library from the UX team and how to integrate CSS and major UI changes into the Dash application.  [https://github.com/CDL-Dryad/stash/blob/master/stash_engine/ui-library/README.md](https://github.com/CDL-Dryad/stash/blob/master/stash_engine/ui-library/README.md)
 
 * Please see [how to set up and run tests locally](local_testing_setup.md) so you can add tests and run current tests to be sure nothing breaks.
 

--- a/documentation/dryad_install.md
+++ b/documentation/dryad_install.md
@@ -1,15 +1,15 @@
-# Dash2 installation (v0.0.1)
+# Dryad installation (v0.0.2)
 
-The Dash2 application is made of a number of parts intended to keep it more flexible and to separate concerns so that parts can be replaced with new metadata and other engines to customize it.  Some basic information about the project and architechiture is available at [the Dash Website](https://dash.ucop.edu/stash/about), but this document focuses on getting Dash up and running for development.
+The Dryad application is made of a number of parts intended to keep it more flexible and to separate concerns so that parts can be replaced with new metadata and other engines to customize it.  Some basic information about the project and architechiture is available at [the Dash Website](https://dash.ucop.edu/stash/about), but this document focuses on getting Dash up and running for development.
 
 ## The ingredients
 
 You'll need the following parts installed and configured on a (local) UI development server to do development on the full UI application.  Don't worry, there are more detailed installation instructions in other sections below and this is meant to give an overview of the larger dependencies to configure.
 
 - (Recommended) A ruby version manager such as [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/)
-- The [bare dashv2 application](https://github.com/CDLUC3/dashv2) cloned from github
-- The [stash](https://github.com/CDLUC3/stash) repository cloned from github
-- A separate directory of configuration files called *dash2-config* which you can start by cloning [dash2-config-example](https://github.com/CDLUC3/dash2-config-example) and modifying to fit your settings.
+- The [bare Drayd application](https://github.com/CDL-Dryad/dryad) cloned from github
+- The [stash](https://github.com/CDL-Dryad/stash) repository cloned from github
+- A separate directory of configuration files called *dryad-config* which you can start by cloning [dryad-config-example](https://github.com/CDL-Dryad/dryad-config-example) and modifying to fit your settings.
 
 You'll also need the following components installed either on the same server or on separate servers for all the application features to work:
 
@@ -29,16 +29,16 @@ The application also requires some means to log in outside of a development envi
 Open a (bash) shell and type these commands inside a directory where you want to work with this code. These will clone the development code and an example config.
 
 ```
-git clone https://github.com/CDLUC3/dashv2
-git clone https://github.com/CDLUC3/stash
-git clone https://github.com/CDLUC3/dash2-config-example.git dash2-config
+git clone https://github.com/CDL-Dryad/dryad
+git clone https://github.com/CDL-Dryad/stash
+git clone https://github.com/CDL-Dryad/dryad-config-example.git dryad-config
 ```
 
 You should end up with a directory structure that looks like this one.
 
 ```
-├── dash2-config
-├── dashv2
+├── dryad-config
+├── dryad
 └── stash
     ├── stash-harvester
     ├── stash-merritt
@@ -52,7 +52,7 @@ You should end up with a directory structure that looks like this one.
 Your config files are currently in a seperate directory from your application. It can be handy to keep them apart from the application so that you can back them up or commit them to a private repository for configuration separate from the application.  The application will need to have these configuration files symlinked into the application. to symlink the files in using a bash shell, type these commands:
 
 ```
-cd dashv2
+cd dryad
 mkdir config/tenants
 ./symlink_config.sh
 ```
@@ -91,7 +91,7 @@ FLUSH PRIVILEGES;
 
 ```
 
-Now edit the dash2-config/config/database.yml file to fill in the *dashuser* and password you set above in the development environment for that configuration file.
+Now edit the dryad-config/config/database.yml file to fill in the *dashuser* and password you set above in the development environment for that configuration file.
 
 ### Solr
 Solr requires a Java runtime.  Try *java -version* and if it says that "java can be found in the following packages" rather than giving you a version you probably need to install java with a command like *sudo apt-get install default-jre* .
@@ -134,7 +134,7 @@ Verify Solr is set up correctly from the Admin UI:
 
 1. Click the *Documents* tab on the left side.<br>![Documents](images/solr4.png)
 
-2. Find the file *dash2-config/sample\_data/sample\_record.json* in the dash2-config repo.  Open the file in a text editor, select all the text and copy it.
+2. Find the file *dryad-config/sample\_data/sample\_record.json* in the dryad-config repo.  Open the file in a text editor, select all the text and copy it.
 
 3. Paste the text into the *Document(s)* box on the page.<br>![json pasted](images/solr5.png)
 4. Click *Submit Document* and be sure it shows a status of success.<br>![success status](images/solr6.png)
@@ -176,7 +176,7 @@ mysql -u <username> -p
 
 # Use the following two lines.
 USE dash;
-source ../dash2-config/sample_data/sample_record.sql;
+source ../dryad-config/sample_data/sample_record.sql;
 
 # To exit the MySQL client, type *exit* or press ctrl-d
 ```
@@ -216,12 +216,12 @@ We have enabled submission to a SWORD-enabled Merritt repository, but have only 
 
 ### Repository and identifier service configuration
 
-The Stash platform requires an implementation of the [Stash::Repo](https://github.com/CDLUC3/stash/tree/master/lib/stash/repo)
+The Stash platform requires an implementation of the [Stash::Repo](https://github.com/CDL-Dryad/stash/tree/master/lib/stash/repo)
 API for identifier assignment and submission to repositories.
 
-Dash2 uses CDL's EZID service for identifier assignment and stores datasets in the [Merritt](https://merritt.cdlib.org/) repository.
+Dryad uses CDL's EZID service for identifier assignment and stores datasets in the [Merritt](https://merritt.cdlib.org/) repository.
 The Stash::Repo implementation is provided by the [stash-merritt](https://github.com/CDLUC3/stash-merritt) gem, which is included in the application [Gemfile](../../Gemfile)
-and declared by the `repository:` key in [`app_config.yml`](https://github.com/CDLUC3/dash2-config-example/blob/development/config/app_config.yml).
+and declared by the `repository:` key in [`app_config.yml`](https://github.com/CDL-Drayd/dryad-config-example/blob/development/config/app_config.yml).
 EZID and Merritt/SWORD must be configured for each tenant in the apporpriate `tenants/*.yml` file, e.g.
 
 ```yaml

--- a/documentation/how_to_contribute.md
+++ b/documentation/how_to_contribute.md
@@ -16,7 +16,7 @@ The basic flow of this model would be to:
 
 ```
 # for example
-git remote add upstream https://github.com/CDLUC3/dashv2.git
+git remote add upstream https://github.com/CDL-Dryad/dryad.git
 git fetch upstream
 git merge upstream/master
 ```
@@ -46,7 +46,7 @@ Changes to database schemas or model classes
 
 Changes to views
 
-- Did you add major UI changes such as new layouts, css styles or images to the [UI library](https://github.com/CDLUC3/stash/tree/master/stash_engine/ui-library) ?
+- Did you add major UI changes such as new layouts, css styles or images to the [UI library](https://github.com/CDL-Dryad/stash/tree/master/stash_engine/ui-library) ?
 - Are feature tests (browser automation) added or modified in order to test the change?
 
 

--- a/spec/config/solr/conf/TODO.md
+++ b/spec/config/solr/conf/TODO.md
@@ -1,3 +1,3 @@
 # TO DO
 
-- Move this to [stash_discovery](https://github.com/CDLUC3/stash/tree/master/stash_discovery)
+- Move this to [stash_discovery](https://github.com/CDL-Dryad/stash/tree/master/stash_discovery)

--- a/travis-prep.sh
+++ b/travis-prep.sh
@@ -15,11 +15,11 @@ set -e
 if [ ! -d ../stash ]; then
   BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
 
-  echo "Cloning https://github.com/CDLUC3/stash:"
+  echo "Cloning https://github.com/CDL-Dryad/stash:"
   cd ..
 
   set -x
-  git clone https://github.com/CDLUC3/stash
+  git clone https://github.com/CDL-Dryad/stash
 
   echo "Checking out stash branch ${BRANCH}"
 


### PR DESCRIPTION
Update references to GitHub repositories. Mostly, replaces references to the CDLUC3 organization with references to the new CDL-Dryad organization, and updates the corresponding repository names where they have changed. 

Also changes the name "Dash" to "Dryad" in places where it makes sense to change, but *not* in places where the underlying resources are still named "Dash".