### PR TITLE
By default, ignore changes to Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,9 +70,13 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
 # .ruby-version
 # .ruby-gemset
+
+# If you need to run a bundle update for incompatibility reasons, 
+# do a force add: `git add -f Gemfile.lock`
+# Otherwise, your local changes to your own Gemfile.lock will be ignored.
+Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc


### PR DESCRIPTION
We should definitely be syncing and updating Gemfile.lock in the repo, but IMO we don't need to deal with merge conflicts to every random time I run `bundle update` for obscure reasons I don't remember and have nothing to do with the pull request I'm making. 

My proposal is that, by default, changes to Gemfile.lock should be ignored, but we can manually force the update of the repository's version in a pull request that needs it, and then explain why we needed it then. That way, we'll have a better searchable log of the reason we updated Gemfile.lock, and not just whenever someone ran `bundle update`.