### PR TITLE
Adding Capybara interface tests for data migration

### DIFF
--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,5 +1,4 @@
 require 'features_helper'
-require 'byebug'
 
 describe 'login/logout' do
   before(:each) do

--- a/spec/features/migrate_data_spec.rb
+++ b/spec/features/migrate_data_spec.rb
@@ -1,0 +1,65 @@
+require 'features_helper'
+require 'byebug'
+
+describe 'migrate_data ' do
+  before(:each) do
+    log_in!
+  end
+
+  it 'shows migrate data' do
+    expect(page).to have_text('Are you missing data')
+  end
+
+  it "makes 'no' in migrate dialog permanantly hide migration info" do
+    first(:link_or_button, 'No').click
+    visit('/stash/dashboard')
+    expect(page.has_no_text?('Are you missing data')).to eq(true)
+  end
+
+  it 'goes to migration if clicking yes in migrate banner dialog' do
+    first(:link_or_button, 'Yes. Migrate my data.').click
+    expect(page).to have_text('Migrate Your Data')
+  end
+
+  it 'gives error for badly formatted email' do
+    visit('/stash/auth/migrate/mail')
+    fill_in 'email', with: 'brr'
+    first(:link_or_button, 'Send code').click
+    expect(page).to have_text('Please fill in a correct email address')
+  end
+
+  it 'gives error for badly formatted code' do
+    visit('/stash/auth/migrate/mail')
+    fill_in 'code', with: 'yack'
+    first(:link_or_button, 'Migrate data').click
+    expect(page).to have_text('Please enter your 6-digit code to migrate your data')
+  end
+
+  it 'errors with a bad code' do
+    visit('/stash/auth/migrate/mail')
+    fill_in 'code', with: '000000'
+    first(:link_or_button, 'Migrate data').click
+    expect(page).to have_text('The code you entered is incorrect')
+  end
+
+  it 'locks out with too many guesses' do
+    visit('/stash/auth/migrate/mail')
+    5.times do
+      fill_in 'code', with: '000000'
+      first(:link_or_button, 'Migrate data').click
+      expect(page).to have_text('The code you entered is incorrect')
+    end
+    fill_in 'code', with: '000000'
+    first(:link_or_button, 'Migrate data').click
+    expect(page).to have_text("You've had too many incorrect code validation attempts.")
+  end
+
+  it 'finishes migration if right code is entered' do
+    visit('/stash/auth/migrate/mail')
+    valid_token = ActiveRecord::Base.connection.select_all('SELECT * FROM stash_engine_users').first['migration_token']
+    fill_in 'code', with: valid_token
+    first(:link_or_button, 'Migrate data').click
+    expect(page).to have_text('Your old Dryad data packages and submissions have now been connected')
+  end
+
+end

--- a/spec/features/migrate_data_spec.rb
+++ b/spec/features/migrate_data_spec.rb
@@ -32,7 +32,7 @@ describe 'migrate_data ' do
     visit('/stash/auth/migrate/mail')
     fill_in 'code', with: 'yack'
     first(:link_or_button, 'Migrate data').click
-    expect(page).to have_text('Please enter your 6-digit code to migrate your data')
+    expect(page).to have_text('Please enter your correct 6-digit code to migrate your data')
   end
 
   it 'errors with a bad code' do

--- a/spec/features/review_spec.rb
+++ b/spec/features/review_spec.rb
@@ -1,5 +1,4 @@
 require 'features_helper'
-require 'byebug'
 
 describe 'review ' do
   before(:each) do

--- a/spec/fixtures/stash_engine_users.yml
+++ b/spec/fixtures/stash_engine_users.yml
@@ -9,6 +9,8 @@ mary_mccormick:
   last_login: 2017-08-24 21:00:08.000000000 Z
   role: user
   orcid: 1234-5878-1234-5678
+  migration_token: 123456
+  old_dryad_email: grog.the.grog@mailinator.com
 
 leroy_jones:
   id: 2
@@ -20,7 +22,7 @@ leroy_jones:
   tenant_id: dryad
   last_login: 2017-08-24 21:15:46.000000000 Z
   role: user
-  orcid: ''
+  orcid: '1234-5878-1234-5601'
 
 grolinda_nagios:
   id: 3
@@ -32,7 +34,7 @@ grolinda_nagios:
   tenant_id: ucop
   last_login: 2017-08-24 21:32:22.000000000 Z
   role: superuser
-  orcid: ''
+  orcid: '1234-5878-1234-5602'
 
 lolinda_myadmin:
   id: 4
@@ -44,4 +46,4 @@ lolinda_myadmin:
   tenant_id: ucop
   last_login: 2017-08-24 21:32:22.000000000 Z
   role: admin
-  orcid: ''
+  orcid: '1234-5878-1234-5603'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,3 +25,4 @@ STASH_DATACITE_PATH = Gem::Specification.find_by_name('stash_datacite').gem_dir
 STASH_DISCOVERY_PATH = Gem::Specification.find_by_name('stash_discovery').gem_dir
 
 require 'mocks/mock_repository.rb'
+ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
You should see the browser run through many tests for the data migration bit.

The output from rspec with capybara should show these tests passing.  These tests are dependent on the latest stash codebase being pulled in first.

I also had some data migration problems which I think are fixed for the test environment.

```
migrate_data
  shows migrate data
  makes 'no' in migrate dialog permanantly hide migration info
  goes to migration if clicking yes in migrate banner dialog
  gives error for badly formatted email
  gives error for badly formatted code
  errors with a bad code
  locks out with too many guesses
  finishes migration if right code is entered
```