### PR TITLE
Doorkeeper security updates, though we aren't using implicit grant

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (4.4.0)
+    doorkeeper (4.4.2)
       railties (>= 4.2)
     dotenv (2.5.0)
     dry-configurable (0.7.0)


### PR DESCRIPTION
The updated gem for doorkeeper security in the gemfile.lock.  We're not using implicit grant, though, so apparently not vulnerable, but good to update.