### PR TITLE
Check out master branch by default

### DIFF
--- a/travis-prep.sh
+++ b/travis-prep.sh
@@ -27,6 +27,7 @@ if [ ! -d ../stash ]; then
   cd stash
   git checkout ${BRANCH}
   if [ $? -ne 0 ]; then
+    echo "No such branch ${BRANCH}, checking out master"
     git checkout master
   fi
   

--- a/travis-prep.sh
+++ b/travis-prep.sh
@@ -22,12 +22,13 @@ if [ ! -d ../stash ]; then
   set -x
   git clone https://github.com/$GITHUB_USER/stash
 
-  echo "Checking out stash branch ${BRANCH}"
 
   cd stash
-  git checkout ${BRANCH}
-  if [ $? -ne 0 ]; then
-    echo "No such branch ${BRANCH}, checking out master"
+  
+  if git checkout ${BRANCH}; then
+    echo "Checking out stash branch ${BRANCH}"
+  else 
+    echo "No branch ${BRANCH}, checking out master"
     git checkout master
   fi
   

--- a/travis-prep.sh
+++ b/travis-prep.sh
@@ -26,10 +26,14 @@ if [ ! -d ../stash ]; then
 
   cd stash
   git checkout ${BRANCH}
+  if [ $? -ne 0 ]; then
+    git checkout master
+  fi
+  
   { set +x; } 2>/dev/null
 
   SE_REVISION=$(git rev-parse HEAD)
-  echo "Checked out stash branch ${BRANCH}, revision ${SE_REVISION}"
+  echo "Checked out stash revision ${SE_REVISION}"
 
   cd ${PROJECT_ROOT}
 fi


### PR DESCRIPTION
I added a conditional so that if `git checkout ${BRANCH}` doesn't work because there is no matching stash branch, it will just check out master instead.