### PR TITLE
Make it more obvious that a password needs to be supplied

### DIFF
--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -9,7 +9,7 @@ defaults: &DEFAULTS
     authorize_url: https://sandbox.orcid.org/oauth/authorize
     token_url: https://api.sandbox.orcid.org/oauth/token
     key:  APP-I07IMI2NJTMP9Z6G
-    secret: 12345
+    secret: <REPLACE-ME>
     member: true
     sandbox: true
     api: https://api.sandbox.orcid.org


### PR DESCRIPTION
When just looking through this file, it is not immediately obvious that the ORCID secret is just a placeholder that needs to be replaced. This change makes it more obvious.