### PR TITLE
set default branch to "development"

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,9 @@ set :application, 'dryad'
 set :repo_url, 'https://github.com/CDL-Dryad/dryad.git'
 
 # Default branch is :master -- uncomment this to prompt for branch name
-ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp unless ENV['BRANCH']
+# ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp unless ENV['BRANCH']
+# Actually, use development for default branch
+set :branch, 'development'
 set :branch, ENV['BRANCH'] if ENV['BRANCH']
 
 # Default deploy_to directory is /var/www/my_app_name


### PR DESCRIPTION
I made branches called development at CDL-Dryad/stash, CDL-Dryad/dryad, and cdlib/dryad-config. When we make pull requests that we’d like to deploy on the dev server, we can merge them into that development branch, push to origin, and then run `cap development deploy` to deploy again.