### PR TITLE
A task to clear out datasets and to destroy them from solr

### DIFF
--- a/lib/tasks/app_data.rake
+++ b/lib/tasks/app_data.rake
@@ -1,12 +1,5 @@
 require_relative '../../script/clear_data'
 namespace :app_data do
-  desc 'Clear data from database (stash and datacite) and solr for environment'
-  task clear: :environment do
-    puts "Are you sure you want to clear the data in the environment #{Rails.env}?  (Type 'yes' to proceed.)"
-    response = STDIN.gets
-    ClearData.clear if response.strip.casecmp('YES').zero? && Rails.env != 'production'
-  end
-
   desc 'Clear just the identifiers and dependent items from database and clear out SOLR'
   task clear_datasets: :environment do
     puts "Are you sure you want to clear the data in the environment #{Rails.env}?  (Type 'yes' to proceed.)"

--- a/lib/tasks/app_data.rake
+++ b/lib/tasks/app_data.rake
@@ -6,4 +6,11 @@ namespace :app_data do
     response = STDIN.gets
     ClearData.clear if response.strip.casecmp('YES').zero? && Rails.env != 'production'
   end
+
+  desc 'Clear just the identifiers and dependent items from database and clear out SOLR'
+  task clear_datasets: :environment do
+    puts "Are you sure you want to clear the data in the environment #{Rails.env}?  (Type 'yes' to proceed.)"
+    response = STDIN.gets
+    ClearData.clear_datasets if response.strip.casecmp('YES').zero? && Rails.env != 'production'
+  end
 end

--- a/script/clear_data.rb
+++ b/script/clear_data.rb
@@ -1,28 +1,5 @@
 module ClearData
 
-  def self.clear
-    to_truncate = %w(bookmarks dcs_affiliations_contributors
-      dcs_alternate_identifiers dcs_contributors dcs_dates dcs_descriptions
-      dcs_formats dcs_geo_location_boxes dcs_geo_location_places dcs_geo_location_points dcs_geo_locations
-      dcs_languages dcs_name_identifiers dcs_publication_years dcs_publishers dcs_related_identifiers
-      dcs_resource_types dcs_rights dcs_sizes dcs_subjects_stash_engine_resources
-      dcs_versions searches stash_engine_authors stash_engine_embargoes stash_engine_file_uploads stash_engine_identifiers
-      stash_engine_resource_states stash_engine_resource_usages stash_engine_resources stash_engine_submission_logs
-      stash_engine_versions users)
-
-    to_truncate.each do |t|
-      query = "TRUNCATE TABLE #{t}"
-      result = ActiveRecord::Base.connection.execute(query)
-      puts "Truncating table #{t}"
-    end
-
-    query = "DELETE FROM dcs_affiliations WHERE abbreviation IS NULL AND short_name IS NULL"
-    result = ActiveRecord::Base.connection.execute(query)
-    puts "Removing extra records from affiliations"
-
-    clear_solr
-  end
-
   def self.clear_datasets
     StashEngine::Identifier.all.each do |iden|
       puts "Destroying #{iden.identifier}"

--- a/script/clear_data.rb
+++ b/script/clear_data.rb
@@ -1,4 +1,4 @@
-class ClearData
+module ClearData
 
   def self.clear
     to_truncate = %w(bookmarks dcs_affiliations_contributors
@@ -20,11 +20,22 @@ class ClearData
     result = ActiveRecord::Base.connection.execute(query)
     puts "Removing extra records from affiliations"
 
+    clear_solr
+  end
 
+  def self.clear_datasets
+    StashEngine::Identifier.all.each do |iden|
+      puts "Destroying #{iden.identifier}"
+      iden.destroy
+    end
+    clear_solr
+  end
+
+  def self.clear_solr
     clear_solr_url = "#{Blacklight.connection_config[:url]}/update?stream.body" +
         '=<delete><query>*:*</query></delete>&commit=true'
 
-    puts "Clearing solr"
+    puts "Clearing solr with #{clear_solr_url}"
 
     # the following, commented out, is a query test to see if SOLR blacklight is accessible
     #response = HTTParty.get("#{Blacklight.connection_config[:url]}/select?q=*%3A*&wt=json&indent=true")


### PR DESCRIPTION
This will clear datasets and destroy them from solr so long as the dependent: true is set correctly in the activerecord models.

I tested this when transitioning dryad-dev to a new merritt collection and it worked, though was a bit slow to destroy a lot of records.