### PR TITLE
Fixing the rake task that updates the sizes from Merritt

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -22,6 +22,8 @@ namespace :dev_ops do
       next
     end
     StashEngine::Identifier.where(storage_size: nil).each do |i|
+      lsr = i.last_submitted_resource
+      next if lsr.nil? || lsr.download_uri.blank? || lsr.update_uri.blank?
       puts "Adding size to #{i}"
       ds_info = Stash::Repo::DatasetInfo.new(i)
       i.update(storage_size: ds_info.dataset_size)


### PR DESCRIPTION
This is a task that triggers size updates based on the Merritt reported sizes for an object (which are compressed and include all versions).

They had a config problem on their end where they were not returning the manifests where we got the size.

The only change is to skip updating size on any datasets that aren't successfully submitted to Merritt or that don't have URLs as supplied by Merritt-Sword.

The lack of these URLs means we cannot query Merrritt for size because we need to use their internal identifier (supplied in their URLs) in order to construct a correct URL.