### PR TITLE
Add default_tenant to example

### DIFF
--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -4,6 +4,7 @@ defaults: &DEFAULTS
   repository: Stash::Merritt::Repository
   stash_mount: /stash
   max_review_days: 180
+  default_tenant: dryad
   orcid:
     site: https://sandbox.orcid.org/
     authorize_url: https://sandbox.orcid.org/oauth/authorize


### PR DESCRIPTION
This is necessary for some functionality, even in test environments where other config is not needed.