### PR TITLE
Moving byebug into both development and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,6 @@ group :development do
 end
 
 group :test do
-  # Ruby fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
-  gem 'byebug'
   # Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb (https://github.com/teamcapybara/capybara)
   gem 'capybara'
   # Automatically create snapshots when Cucumber steps fail with Capybara and Rails (http://github.com/mattheworiordan/capybara-screenshot)
@@ -100,6 +98,8 @@ group :test do
 end
 
 group :development, :test do
+  # Ruby fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
+  gem 'byebug'
   gem 'binding_of_caller'
   gem 'pry'
   gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -98,9 +98,9 @@ group :test do
 end
 
 group :development, :test do
+  gem 'binding_of_caller'
   # Ruby fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
   gem 'byebug'
-  gem 'binding_of_caller'
   gem 'pry'
   gem 'pry-rails'
   gem 'pry-remote'

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -55,6 +55,7 @@ module DatasetHelper
   end
 
   def fill_article_info(name:, msid:)
+    choose('choose_manuscript')
     fill_in 'internal_datum[publication_name]', with: name
     fill_in 'internal_datum[msid]', with: msid
   end


### PR DESCRIPTION
I moved byebug into development and test environments since I use it in development mode for debugging, also.   Also fixing test for form to be sure it displays a message about not being able to find.

It looks like it won't pass until the merge of stash repo is done first for these UI changes.