### PR TITLE
Expand documentation for curation status

### DIFF
--- a/documentation/api_submission.md
+++ b/documentation/api_submission.md
@@ -106,7 +106,7 @@ To see the dataset fields and option in use, see the [Sample Dataset Object](htt
 Useful options that control a dataset's behavior:
 - `skipDataciteUpdate` - If true, doesn't send any requests to DataCite when registering the dataset. This is useful when the dataset already has a DOI, which is present in the metadata being submitted.
 - `skipEmails` - If true, prevents emails from being sent to users on submission. Prevents emails regardless of whether the submission is successful or an error. Also stopps the emails that ask co-authors to register their ORCID. Does *not* stop the internal emails that are sent to Dryad admins if there is a submission error.
-- `preserveCurationStatus` - If true, prevents Dryad from automatically setting the curation status to "in progress". This is useful when the dataset already has a curation status that will be set in a later API call.
+- `preserveCurationStatus` - If true, prevents Dryad from automatically setting the curation status to "submitted". This is useful when the dataset already has a curation status that will be set in a later API call.
 - `loosenValidation` - Allows a dataset to be processed even if author information is incomplete (e.g., missing affiliations), or if the abstract is missing. It does still perform some basic validation of the dataset.
 
 The above settings get carried with a dataset into future API submissions, but the UI resets all of these values to `false` so that people can't avoid being good research citizens when they manually update their datasets. These settings are hidden when they're in the default (false) state to keep people from seeing them and trying to set them (since most people can't set them).

--- a/documentation/api_submission.md
+++ b/documentation/api_submission.md
@@ -106,6 +106,7 @@ To see the dataset fields and option in use, see the [Sample Dataset Object](htt
 Useful options that control a dataset's behavior:
 - `skipDataciteUpdate` - If true, doesn't send any requests to DataCite when registering the dataset. This is useful when the dataset already has a DOI, which is present in the metadata being submitted.
 - `skipEmails` - If true, prevents emails from being sent to users on submission. Prevents emails regardless of whether the submission is successful or an error. Also stopps the emails that ask co-authors to register their ORCID. Does *not* stop the internal emails that are sent to Dryad admins if there is a submission error.
+- `preserveCurationStatus` - If true, prevents Dryad from automatically setting the curation status to "in progress". This is useful when the dataset already has a curation status that will be set in a later API call.
 - `loosenValidation` - Allows a dataset to be processed even if author information is incomplete (e.g., missing affiliations), or if the abstract is missing. It does still perform some basic validation of the dataset.
 
 The above settings get carried with a dataset into future API submissions, but the UI resets all of these values to `false` so that people can't avoid being good research citizens when they manually update their datasets. These settings are hidden when they're in the default (false) state to keep people from seeing them and trying to set them (since most people can't set them).

--- a/documentation/sample_dataset.json
+++ b/documentation/sample_dataset.json
@@ -59,8 +59,9 @@
 			 "neLatitude": "38.0"
 			 }
 		 }
-		],
- "skipDataciteUpdate" : true,
- "skipEmails" : true,
- "loosenValidation" : true
+	      ],
+    "skipDataciteUpdate" : true,
+    "skipEmails" : true,
+    "loosenValidation" : true,
+    "preserveCurationStatus": true
 }

--- a/documentation/submission_flow.md
+++ b/documentation/submission_flow.md
@@ -1,4 +1,5 @@
-Dash Submission Flow
+Basic Dryad Submission Flow
+=============================
 
 1. Fill in metadata (DataCite)
     * Mostly AJAX in one page by way of JQuery and/or Rails Unobtrusive Javascript (UJS)
@@ -30,3 +31,42 @@ Dash Submission Flow
     * Cleans up staged, temporary files for this submission
     * Delivers invitations for co-authors without ORCIDs
     * Updates the total dataset size by querying Merritt
+
+
+Merritt States
+=================
+
+The Merritt status is stored in resource.current_resource_state (StashEngine::ResourceState).
+Allowable values:
+- in_progress = someone is editing and hasn't submitted this version to Merritt yet
+- processing = processing through Merritt as a submission right now (or maybe stalled in rare circumstances)
+- submitted = submitted to Merritt successfully
+- error = some error occurred while submitting to Merritt
+
+stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
+- See the update method. This gets called back by the notifier service
+  which is reading an OAI-PMH feed from Merritt which lists things that
+  have gone in successfully.  
+- This sets the merritt-status (stash_engine_resource_states) to 'submitted'.
+- It will not set the completed, 'submitted' state more than once, so
+  calling additional times will not have an effect (it returns early if
+  it has already been updated). 
+- updates size based on querying Merritt to get size after it was compressed/ingested.
+- populates SWORD-type URLs if they're missing for some reason.
+- cleans up temp files now that Merritt has told us ingest was successful.
+
+Curation Status
+=====================
+
+Curation status is stored in resource.current_curation_activity (StashEngine::CurationActivity).
+
+Allowable values:
+- in_progress = the submitter is still working on the resource
+- submitted = the submitter has submitted the resource for curation, but a curator has not picked it up yet
+- peer_review = the resource is availble for reviewers to view, but curators will ignore it
+- curation = a curator is working on the resource
+- action_required = a curator has returned the resource to submitter for revision
+- withdrawn = a previously-published resource has been removed from public view
+- embargoed = metadata for the resource is published, but data files are not publicly available
+- published = the resource is fully available to the public
+


### PR DESCRIPTION
Add documentation for the `preserveCurationStatus` API option.

Add documentation of the resource status settings, both Merritt status and curation status.