### PR TITLE
This adds some "requests" API testing of basic metadata submission and placenames

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ begin
     task.rspec_opts = %w[--color --format documentation --order random]
   end
 
-  task default: %i[rubocop spec]
+  task default: %i[db:migrate rubocop spec]
 rescue LoadError
   puts 'There was an error and rspec was not available.'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ begin
     task.rspec_opts = %w[--color --format documentation --order random]
   end
 
-  task default: %i[db:migrate rubocop spec]
+  task default: %i[rubocop spec]
 rescue LoadError
   puts 'There was an error and rspec was not available.'
 end

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -1,6 +1,7 @@
 require 'faker'
 require 'json'
 
+# rubocop:disable Metrics/ClassLength
 module Fixtures
   module StashApi
     class Metadata
@@ -51,47 +52,47 @@ module Fixtures
       def add_point
         create_key_and_array(key: :locations)
         @metadata[:locations].push(
-            point: random_point
+          point: random_point
         )
       end
 
       def add_box
         create_key_and_array(key: :locations)
         @metadata[:locations].push(
-            box: random_box
+          box: random_box
         )
       end
 
       def add_associated_place_and_point
         create_key_and_array(key: :locations)
         @metadata[:locations].push(
-            place: random_placename,
-            point: random_point
+          place: random_placename,
+          point: random_point
         )
       end
 
       def add_associated_place_and_box
         create_key_and_array(key: :locations)
         @metadata[:locations].push(
-            place: random_placename,
-            box: random_box
+          place: random_placename,
+          box: random_box
         )
       end
 
       def add_associated_place_point_and_box
         create_key_and_array(key: :locations)
         @metadata[:locations].push(
-            place: random_placename,
-            point: random_point,
-            box: random_box
+          place: random_placename,
+          point: random_point,
+          box: random_box
         )
       end
 
       def add_associated_point_and_box
         create_key_and_array(key: :locations)
         @metadata[:locations].push(
-            point: random_point,
-            box: random_box
+          point: random_point,
+          box: random_box
         )
       end
 
@@ -127,3 +128,4 @@ module Fixtures
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -1,44 +1,46 @@
 require 'faker'
 require 'json'
 
-module StashApi
-  class Metadata
+module Fixtures
+  module StashApi
+    class Metadata
 
-    def initialize
-      @metadata = ActiveSupport::HashWithIndifferentAccess.new
+      def initialize
+        @metadata = ActiveSupport::HashWithIndifferentAccess.new
+      end
+
+      def hash
+        @metadata.with_indifferent_access
+      end
+
+      def json
+        @metadata.to_json
+      end
+
+      def make_minimal
+        add_title
+        add_abstract
+        add_author
+      end
+
+      def add_title
+        @metadata.merge!(title: Faker::Book.title)
+      end
+
+      def add_author
+        @metadata[:authors] = [] unless @metadata['authors']
+        @metadata[:authors].push(
+          { "firstName": Faker::Name.first_name,
+            "lastName": Faker::Name.last_name,
+            email: Faker::Internet.email,
+            affiliation: Faker::University.name }.with_indifferent_access
+        )
+      end
+
+      def add_abstract
+        @metadata.merge!(abstract: Faker::Lorem.paragraph)
+      end
+
     end
-
-    def hash
-      @metadata.with_indifferent_access
-    end
-
-    def json
-      @metadata.to_json
-    end
-
-    def make_minimal
-      add_title
-      add_abstract
-      add_author
-    end
-
-    def add_title
-      @metadata.merge!(title: Faker::Book.title)
-    end
-
-    def add_author
-      @metadata[:authors] = [] unless @metadata['authors']
-      @metadata[:authors].push(
-        { "firstName": Faker::Name.first_name,
-        "lastName": Faker::Name.last_name,
-        email: Faker::Internet.email,
-        affiliation: Faker::University.name }.with_indifferent_access
-      )
-    end
-
-    def add_abstract
-      @metadata.merge!(abstract: Faker::Lorem.paragraph)
-    end
-
   end
 end

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -1,0 +1,44 @@
+require 'faker'
+require 'json'
+
+module StashApi
+  class Metadata
+
+    def initialize
+      @metadata = ActiveSupport::HashWithIndifferentAccess.new
+    end
+
+    def hash
+      @metadata.with_indifferent_access
+    end
+
+    def json
+      @metadata.to_json
+    end
+
+    def make_minimal
+      add_title
+      add_abstract
+      add_author
+    end
+
+    def add_title
+      @metadata.merge!(title: Faker::Book.title)
+    end
+
+    def add_author
+      @metadata[:authors] = [] unless @metadata['authors']
+      @metadata[:authors].push(
+        { "firstName": Faker::Name.first_name,
+        "lastName": Faker::Name.last_name,
+        email: Faker::Internet.email,
+        affiliation: Faker::University.name }.with_indifferent_access
+      )
+    end
+
+    def add_abstract
+      @metadata.merge!(abstract: Faker::Lorem.paragraph)
+    end
+
+  end
+end

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -28,7 +28,7 @@ module Fixtures
       end
 
       def add_author
-        @metadata[:authors] = [] unless @metadata['authors']
+        create_key_and_array(key: :authors)
         @metadata[:authors].push(
           { "firstName": Faker::Name.first_name,
             "lastName": Faker::Name.last_name,
@@ -39,6 +39,89 @@ module Fixtures
 
       def add_abstract
         @metadata.merge!(abstract: Faker::Lorem.paragraph)
+      end
+
+      def add_place
+        create_key_and_array(key: :locations)
+        @metadata[:locations].push(
+          place: random_placename
+        )
+      end
+
+      def add_point
+        create_key_and_array(key: :locations)
+        @metadata[:locations].push(
+            point: random_point
+        )
+      end
+
+      def add_box
+        create_key_and_array(key: :locations)
+        @metadata[:locations].push(
+            box: random_box
+        )
+      end
+
+      def add_associated_place_and_point
+        create_key_and_array(key: :locations)
+        @metadata[:locations].push(
+            place: random_placename,
+            point: random_point
+        )
+      end
+
+      def add_associated_place_and_box
+        create_key_and_array(key: :locations)
+        @metadata[:locations].push(
+            place: random_placename,
+            box: random_box
+        )
+      end
+
+      def add_associated_place_point_and_box
+        create_key_and_array(key: :locations)
+        @metadata[:locations].push(
+            place: random_placename,
+            point: random_point,
+            box: random_box
+        )
+      end
+
+      def add_associated_point_and_box
+        create_key_and_array(key: :locations)
+        @metadata[:locations].push(
+            point: random_point,
+            box: random_box
+        )
+      end
+
+      def create_key_and_array(key:)
+        @metadata[key] = [] unless @metadata[key]
+      end
+
+      def random_placename
+        case rand(3)
+        when 0
+          Faker::Address.city
+        when 1
+          Faker::Address.state
+        else
+          Faker::Address.country
+        end
+      end
+
+      def random_point
+        { latitude: Faker::Address.latitude,
+          longitude: Faker::Address.longitude }
+      end
+
+      def random_box
+        {
+          "swLongitude": Faker::Address.longitude,
+          "swLatitude": Faker::Address.latitude,
+          "neLongitude": Faker::Address.longitude,
+          "neLatitude": Faker::Address.latitude
+        }
       end
 
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,4 +74,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # force a rake run before test suite
+  config.before(:suite) do
+    output = `rake db:migrate`
+    puts output
+  end
 end

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -4,7 +4,7 @@ require 'fixtures/stash_api/metadata'
 
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
 module StashApi
-  RSpec.describe GeneralController, type: :request do
+  RSpec.describe DatasetsController, type: :request do
 
     before(:all) do
       @user = create(:user, role: 'superuser')
@@ -25,7 +25,13 @@ module StashApi
         response_code = post '/api/datasets', @meta.json, default_authenticated_headers
         output = JSON.parse(response.body).with_indifferent_access
         expect(response_code).to eq(201)
-        expect(/doi:10\.5072\/dryad\..{8}/).to match(output[:identifier])
+        expect(%r{doi:10.5072/dryad\..{8}}).to match(output[:identifier])
+        hsh = @meta.hash
+        expect(hsh[:title]).to eq(output[:title])
+        expect(hsh[:abstract]).to eq(output[:abstract])
+        in_author = hsh[:authors].first
+        out_author = output[:authors].first
+        expect(in_author).to eq(out_author)
       end
     end
   end

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -33,6 +33,22 @@ module StashApi
         out_author = output[:authors].first
         expect(in_author).to eq(out_author)
       end
+
+      it 'creates a new basic dataset with a placename' do
+        @meta.add_place
+        response_code = post '/api/datasets', @meta.json, default_authenticated_headers
+        output = JSON.parse(response.body).with_indifferent_access
+        expect(response_code).to eq(201)
+
+        # check it against the database
+        @stash_id = StashEngine::Identifier.find(output[:id])
+        @resource = @stash_id.resources.first
+        expect(@resource.geolocations.first.geolocation_place.geo_location_place).to eq(@meta.hash[:locations].first[:place])
+
+        # check it against the return json
+        expect(output[:locations].first[:place]).to eq(@meta.hash[:locations].first[:place])
+      end
+
     end
   end
 end

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require_relative 'helpers'
+require 'fixtures/stash_api/metadata'
+
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashApi
+  RSpec.describe GeneralController, type: :request do
+
+    before(:all) do
+      @user = create(:user, role: 'superuser')
+      @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                                                owner_id: @user.id, owner_type: 'StashEngine::User')
+      setup_access_token(doorkeeper_application: @doorkeeper_application)
+    end
+
+    # test creation of a new dataset
+    describe '#create' do
+      before(:each) do
+        @meta = StashApi::Metadata.new
+        @meta.make_minimal
+      end
+
+      it 'creates a new dataset from minimal metadata (title, author info, abstract)' do
+        expect(true).to eq(true)
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -3,6 +3,7 @@ require_relative 'helpers'
 require 'fixtures/stash_api/metadata'
 
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+# rubocop:disable Metrics/BlockLength
 module StashApi
   RSpec.describe DatasetsController, type: :request do
 

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -16,12 +16,16 @@ module StashApi
     # test creation of a new dataset
     describe '#create' do
       before(:each) do
-        @meta = StashApi::Metadata.new
+        @meta = Fixtures::StashApi::Metadata.new
         @meta.make_minimal
       end
 
       it 'creates a new dataset from minimal metadata (title, author info, abstract)' do
-        expect(true).to eq(true)
+        # the following works for post with headers
+        response_code = post '/api/datasets', @meta.json, default_authenticated_headers
+        output = JSON.parse(response.body).with_indifferent_access
+        expect(response_code).to eq(201)
+        expect(/doi:10\.5072\/dryad\..{8}/).to match(output[:identifier])
       end
     end
   end


### PR DESCRIPTION
Changes:

- Added methods for creating API test hashes using faker
- Basic sanity-check test for submitting the required base metadata and for some important return items.
- Test for adding a place name and that it is reflected correctly both in the database and the returned JSON from the API.

Added a place name to a record it shows up OK for me. https://dryad-dev.cdlib.org/stash/dataset/doi:10.5072/FK27M0CF0W

You can run just this test with `bundle exec rspec spec/responses/stash_api/datasets_controller_spec.rb`  Add -fd if you want to see the names of the tests being run.

@ryscher can you let me know what JSON you are using to add place names?

