### PR TITLE
Separate host and port, so counter_logger works properly

### DIFF
--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -42,6 +42,6 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
-  Rails.application.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000}
+  Rails.application.default_url_options = { host: 'localhost', port: 3000}
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
-  Rails.application.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  Rails.application.default_url_options = { host: 'localhost', port: 3000 }
 end


### PR DESCRIPTION
When running in a `local` environment, if the host and port are together, any time a landing page is viewed, the counter_logger will throw `URI::InvalidComponentError: bad component(expected host component): localhost:3000`. Separating them allows counter_logger to access the host separately and avoid the error.