### PR TITLE
Make stage deploy work for two servers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -98,7 +98,7 @@ namespace :deploy do
   end
 
   after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
+    on roles(:app), in: :groups, limit: 3, wait: 10 do
       # Here we can do anything such as:
       # within release_path do
       #   execute :rake, 'cache:clear'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -56,6 +56,16 @@ set :passenger_port, "3000"
 
 TAG_REGEXP = /^[v\d\.]{3,}.*$/.freeze
 
+namespace :debug do
+  desc 'Print ENV variables'
+  task :env do
+    on roles(:app), in: :sequence, wait: 5 do
+      execute :whoami
+      execute :printenv
+    end
+  end
+end
+
 namespace :deploy do
 
   desc 'Get list of linked files for capistrano'
@@ -80,7 +90,7 @@ namespace :deploy do
 
   desc 'update config repo'
   task :update_config do
-    on roles(:app) do
+    on roles(:app), in: :sequence, wait: 5 do
       my_branch = fetch(:branch, 'development')
       my_branch = "origin/#{my_branch}" unless my_branch.match(TAG_REGEXP) #git acts differently with tags (regex for version #s)
       execute "cd #{deploy_to}/shared; git fetch --tags; git fetch --all; git reset --hard #{my_branch}"

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -11,10 +11,11 @@ set :rails_env, 'demo'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'demo' }
 
-# To override the default host, set $SERVER_HOST, e.g.
-#    $ SERVER_HOST='localhost' bundle exec cap development deploy
-set :server_host, ENV["SERVER_HOST"] || 'uc3-dashdemo-stg.cdlib.org'
-server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+# To override the default host, set $SERVER_HOSTS, e.g.
+#    $ SERVER_HOSTS='localhost1 localhost2' bundle exec cap development deploy
+set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || ['uc3-dashdemo-stg.cdlib.org']
+role :web, fetch(:server_hosts), user: 'dryad'
+role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|
 #  puts "setting server host: #{host.hostname}"

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -14,7 +14,6 @@ set :rails_env, 'demo'
 # To override the default host, set $SERVER_HOSTS, e.g.
 #    $ SERVER_HOSTS='localhost1 localhost2' bundle exec cap development deploy
 set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || ['uc3-dashdemo-stg.cdlib.org']
-role :web, fetch(:server_hosts), user: 'dryad'
 role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -9,10 +9,11 @@
 
 set :rails_env, "development"
 
-# To override the default host, set $SERVER_HOST, e.g.
-#    $ SERVER_HOST='localhost' bundle exec cap development deploy
-set :server_host, ENV["SERVER_HOST"] || 'uc3-dryad-dev.cdlib.org'
-server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+# To override the default host, set $SERVER_HOSTS, e.g.
+#    $ SERVER_HOSTS='localhost1 localhost2' bundle exec cap development deploy
+set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || 'uc3-dryad-dev.cdlib.org'
+role :web, fetch(:server_hosts), user: 'dryad'
+role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|
 #  puts "setting server host: #{host.hostname}"

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -12,7 +12,6 @@ set :rails_env, "development"
 # To override the default host, set $SERVER_HOSTS, e.g.
 #    $ SERVER_HOSTS='localhost1 localhost2' bundle exec cap development deploy
 set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || 'uc3-dryad-dev.cdlib.org'
-role :web, fetch(:server_hosts), user: 'dryad'
 role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,7 +10,7 @@
 set :rails_env, 'production'
 
 set :server_host, ENV["SERVER_HOST"] || 'uc3-dryad-prd.cdlib.org'
-server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+server fetch(:server_host), user: 'dryad', roles: %w{app}
 
 # role-based syntax
 # ==================

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -12,9 +12,10 @@ set :rails_env, 'stage'
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 
 # To override the default host, set $SERVER_HOST, e.g.
-#    $ SERVER_HOST='localhost' bundle exec cap development deploy
-set :server_host, ENV["SERVER_HOST"] || 'uc3-dryad-stg.cdlib.org'
-server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+#    $ SERVER_HOST='localhost1 localhost2' bundle exec cap development deploy
+set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || %w[uc3-dryad-stg.cdlib.org uc3-dryadui-stg-2c.cdlib.org]
+role :web, fetch(:server_hosts), user: 'dryad'
+role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|
 #  puts "setting server host: #{host.hostname}"

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -14,7 +14,6 @@ set :rails_env, 'stage'
 # To override the default host, set $SERVER_HOST, e.g.
 #    $ SERVER_HOST='localhost1 localhost2' bundle exec cap development deploy
 set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || %w[uc3-dryad-stg.cdlib.org uc3-dryadui-stg-2c.cdlib.org]
-role :web, fetch(:server_hosts), user: 'dryad'
 role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|

--- a/config/deploy/stage1.rb
+++ b/config/deploy/stage1.rb
@@ -14,7 +14,6 @@ set :rails_env, 'stage'
 # To override the default host, set $SERVER_HOSTS, e.g.
 #    $ SERVER_HOSTS='localhost' bundle exec cap development deploy
 set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || ['uc3-dryad-stg.cdlib.org']
-role :web, fetch(:server_hosts), user: 'dryad'
 role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|

--- a/config/deploy/stage1.rb
+++ b/config/deploy/stage1.rb
@@ -1,0 +1,76 @@
+# server-based syntax
+# ======================
+# Defines a single server with a list of roles and multiple properties.
+# You can define all roles on a single server, or split them:
+
+# server 'example.com', user: 'deploy', roles: %w{app db web}, my_property: :my_value
+# server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
+# server 'db.example.com', user: 'deploy', roles: %w{db}
+
+set :rails_env, 'stage'
+
+#set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
+
+# To override the default host, set $SERVER_HOST, e.g.
+#    $ SERVER_HOST='localhost' bundle exec cap development deploy
+set :server_host, ENV["SERVER_HOST"] || 'uc3-dryad-stg.cdlib.org'
+server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+
+#on roles(:all) do |host|
+#  puts "setting server host: #{host.hostname}"
+#end
+
+#set :passenger_pid, "#{deploy_to}/passenger.pid"
+#set :passenger_log, "#{deploy_to}/passenger.log"
+#set :passenger_port, "3000"
+
+# role-based syntax
+# ==================
+
+# Defines a role with one or multiple servers. The primary server in each
+# group is considered to be the first unless any  hosts have the primary
+# property set. Specify the username and a domain or IP for the server.
+# Don't use `:all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}, my_property: :my_value
+# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
+# role :db,  %w{deploy@example.com}
+
+
+
+# Configuration
+# =============
+# You can set any configuration variable like in config/deploy.rb
+# These variables are then only loaded and set in this stage.
+# For available Capistrano configuration variables see the documentation page.
+# http://capistranorb.com/documentation/getting-started/configuration/
+# Feel free to add new variables to customise your setup.
+
+
+
+# Custom SSH Options
+# ==================
+# You may pass any option but keep in mind that net/ssh understands a
+# limited set of options, consult the Net::SSH documentation.
+# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
+#
+# Global options
+# --------------
+#  set :ssh_options, {
+#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+#
+# The server-based syntax can be used to override options:
+# ------------------------------------
+# server 'example.com',
+#   user: 'user_name',
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: 'user_name', # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: 'please use keys'
+#   }

--- a/config/deploy/stage1.rb
+++ b/config/deploy/stage1.rb
@@ -11,10 +11,11 @@ set :rails_env, 'stage'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 
-# To override the default host, set $SERVER_HOST, e.g.
-#    $ SERVER_HOST='localhost' bundle exec cap development deploy
-set :server_host, ENV["SERVER_HOST"] || 'uc3-dryad-stg.cdlib.org'
-server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+# To override the default host, set $SERVER_HOSTS, e.g.
+#    $ SERVER_HOSTS='localhost' bundle exec cap development deploy
+set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || ['uc3-dryad-stg.cdlib.org']
+role :web, fetch(:server_hosts), user: 'dryad'
+role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|
 #  puts "setting server host: #{host.hostname}"

--- a/config/deploy/stage2.rb
+++ b/config/deploy/stage2.rb
@@ -1,0 +1,76 @@
+# server-based syntax
+# ======================
+# Defines a single server with a list of roles and multiple properties.
+# You can define all roles on a single server, or split them:
+
+# server 'example.com', user: 'deploy', roles: %w{app db web}, my_property: :my_value
+# server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
+# server 'db.example.com', user: 'deploy', roles: %w{db}
+
+set :rails_env, 'stage'
+
+#set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
+
+# To override the default host, set $SERVER_HOST, e.g.
+#    $ SERVER_HOST='localhost' bundle exec cap development deploy
+set :server_host, ENV["SERVER_HOST"] || 'uc3-dryadui-stg-2c.cdlib.org'
+server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+
+#on roles(:all) do |host|
+#  puts "setting server host: #{host.hostname}"
+#end
+
+#set :passenger_pid, "#{deploy_to}/passenger.pid"
+#set :passenger_log, "#{deploy_to}/passenger.log"
+#set :passenger_port, "3000"
+
+# role-based syntax
+# ==================
+
+# Defines a role with one or multiple servers. The primary server in each
+# group is considered to be the first unless any  hosts have the primary
+# property set. Specify the username and a domain or IP for the server.
+# Don't use `:all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}, my_property: :my_value
+# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
+# role :db,  %w{deploy@example.com}
+
+
+
+# Configuration
+# =============
+# You can set any configuration variable like in config/deploy.rb
+# These variables are then only loaded and set in this stage.
+# For available Capistrano configuration variables see the documentation page.
+# http://capistranorb.com/documentation/getting-started/configuration/
+# Feel free to add new variables to customise your setup.
+
+
+
+# Custom SSH Options
+# ==================
+# You may pass any option but keep in mind that net/ssh understands a
+# limited set of options, consult the Net::SSH documentation.
+# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
+#
+# Global options
+# --------------
+#  set :ssh_options, {
+#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+#
+# The server-based syntax can be used to override options:
+# ------------------------------------
+# server 'example.com',
+#   user: 'user_name',
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: 'user_name', # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: 'please use keys'
+#   }

--- a/config/deploy/stage2.rb
+++ b/config/deploy/stage2.rb
@@ -14,7 +14,6 @@ set :rails_env, 'stage'
 # To override the default host, set $SERVER_HOSTS, e.g.
 #    $ SERVER_HOSTS='localhost' bundle exec cap development deploy
 set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || ['uc3-dryadui-stg-2c.cdlib.org']
-role :web, fetch(:server_hosts), user: 'dryad'
 role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|

--- a/config/deploy/stage2.rb
+++ b/config/deploy/stage2.rb
@@ -11,10 +11,11 @@ set :rails_env, 'stage'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 
-# To override the default host, set $SERVER_HOST, e.g.
-#    $ SERVER_HOST='localhost' bundle exec cap development deploy
-set :server_host, ENV["SERVER_HOST"] || 'uc3-dryadui-stg-2c.cdlib.org'
-server fetch(:server_host), user: 'dryad', roles: %w{web app db}
+# To override the default host, set $SERVER_HOSTS, e.g.
+#    $ SERVER_HOSTS='localhost' bundle exec cap development deploy
+set :server_hosts, ENV["SERVER_HOSTS"]&.split(' ') || ['uc3-dryadui-stg-2c.cdlib.org']
+role :web, fetch(:server_hosts), user: 'dryad'
+role :app, fetch(:server_hosts), user: 'dryad'
 
 #on roles(:all) do |host|
 #  puts "setting server host: #{host.hostname}"


### PR DESCRIPTION
This is now working across either one or both servers on stage.  I created some new deploy environments for stage in case we want to deploy only one.

`cap stage deploy BRANCH=<branch_or_tag>` will deploy to both servers simultaneously.
`cap stage1 deploy BRANCH=<branch_or_tag>` will only deploy to the first server
`cap stage2 deploy BRANCH=<branch_or_tag>` will only deploy to the second server

There are also ways to set the server domain names with an environment variable instead, but I can never remember the extremely long and wonky internal domain names CDL sets up so these deploys are nice conveniences, IMO.

Sorry this took so long.  I wanted to be sure that some things worked right with capistrano and I also ran into a problem where it wasn't logging in with the right user and it took a while to troubleshoot and figure it out.

I'll need to talk to @jimvanderveen about what he wants to do with the init.d scripts on each server that call the capistrano restart.  I think probably we want to change each to only restart the local server (though one could restart both if we wanted).

When we deploy code, we can do one at a time.  In some cases we will not want to since removing fields in the database may make old code break if one of the servers is running old code.  Also capistrano is pretty good about redeploying with little downtime since it creates everything and then symlinks and restarts afterwards which makes downtime of only a few seconds, I think.

I'll also tag @ryscher so he has some background deployment.