### PR TITLE
Make both travis and local tests use dryad-config-example settings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module Dash2
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
     config.generators.javascript_engine = :js
+    config.autoload_paths << Rails.root.join("lib")
   end
 end

--- a/config/initializers/00_tenants.rb
+++ b/config/initializers/00_tenants.rb
@@ -1,6 +1,9 @@
 hsh = HashWithIndifferentAccess.new
 
-Dir.glob(File.join(Rails.root, 'config', 'tenants', '**.yml')).each do |fn|
+tenant_path = (Rails.env == 'test' ? File.join(Rails.root, 'dryad-config-example', 'tenants', '**.yml') :
+                   File.join(Rails.root, 'config', 'tenants', '**.yml') )
+
+Dir.glob(tenant_path).each do |fn|
   h = HashWithIndifferentAccess.new(YAML.load_file(fn)[Rails.env])
   hsh[h[:tenant_id]] = h
 end

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,6 +1,8 @@
 require 'ostruct'
 require 'yaml'
-ac = YAML.load_file(File.join(Rails.root, 'config', 'app_config.yml'))[Rails.env]
+
+# this will interpret any ERB in the yaml file first before bringing in
+ac = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', 'app_config.yml'))).result)[Rails.env]
 
 # this will make the config available under the APP_CONFIG constant and methods like APP_CONFIG.metadata_engines
 APP_CONFIG = ac.to_ostruct

--- a/dryad-config-example/blacklight.yml
+++ b/dryad-config-example/blacklight.yml
@@ -4,7 +4,7 @@ development: &DEVELOPMENT
   url: <%= ENV['SOLR_URL'] || "http://localhost:8983/solr/geoblacklight" %> #change me
 test: &test
   adapter: solr
-  url: "http://127.0.0.1:8983/solr/geoblacklight"
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/geoblacklight" %>
 stage:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://my.solr.stage.domain:8983/solr/geoblacklight" %> #change me

--- a/dryad-config-example/blacklight.yml
+++ b/dryad-config-example/blacklight.yml
@@ -4,9 +4,7 @@ development: &DEVELOPMENT
   url: <%= ENV['SOLR_URL'] || "http://localhost:8983/solr/geoblacklight" %> #change me
 test: &test
   adapter: solr
-  url: http://127.0.0.1:8983/solr/geoblacklight
-  # TODO: Figure out whether we want/need a local Jetty/Solr for testing
-  # url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8888}/solr/blacklight-core" %> #change me
+  url: "http://127.0.0.1:8983/solr/geoblacklight"
 stage:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://my.solr.stage.domain:8983/solr/geoblacklight" %> #change me

--- a/lib/yaml_helper.rb
+++ b/lib/yaml_helper.rb
@@ -1,0 +1,13 @@
+require 'yaml'
+module YamlHelper
+  def self.output_test_section(example_filename:)
+    my_file = Rails.root.join('dryad-config-example', example_filename)
+    # rubocop:disable Security/YAMLLoad
+    # byebug
+    my_yml = YAML.load(ERB.new(File.read(my_file)).result)
+    # rubocop:enable Security/YAMLLoad
+    # my_yml = YAML.load_file(my_file)
+    new_yml = { 'test' => my_yml['test'] }.to_yaml
+    new_yml.split("\n")[1..-1].join("\n") # this gets rid of the --- in the top line which we don't want when emitting
+  end
+end

--- a/lib/yaml_helper.rb
+++ b/lib/yaml_helper.rb
@@ -2,11 +2,10 @@ require 'yaml'
 module YamlHelper
   def self.output_test_section(example_filename:)
     my_file = Rails.root.join('dryad-config-example', example_filename)
+    # have to enable parsing of the blacklight.yml file for now
     # rubocop:disable Security/YAMLLoad
-    # byebug
     my_yml = YAML.load(ERB.new(File.read(my_file)).result)
     # rubocop:enable Security/YAMLLoad
-    # my_yml = YAML.load_file(my_file)
     new_yml = { 'test' => my_yml['test'] }.to_yaml
     new_yml.split("\n")[1..-1].join("\n") # this gets rid of the --- in the top line which we don't want when emitting
   end

--- a/spec/features/stash_discovery/solr_sanitization_spec.rb
+++ b/spec/features/stash_discovery/solr_sanitization_spec.rb
@@ -7,8 +7,10 @@ RSpec.feature 'SolrSanitization', type: :feature do
     # Start Solr - shutdown is handled globally when all tests have finished
     SolrInstance.instance
 
-    solr_url = YAML.safe_load(File.read(SolrInstance::BLACKLIGHT_YML), [], [], true)['test']['url']
-    @solr = RSolr.connect(url: solr_url)
+    # rubocop:disable Security/YAMLLoad
+    doc = YAML.load(ERB.new(File.read(File.join(Rails.root, SolrInstance::BLACKLIGHT_YML))).result)
+    # rubocop:enable Security/YAMLLoad
+    @solr = RSolr.connect(url: doc['test']['url'])
 
     @uuid = Faker::Crypto.sha1
   end

--- a/spec/lib/yaml_helper_spec.rb
+++ b/spec/lib/yaml_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'yaml'
+RSpec.describe YamlHelper do
+
+  describe 'self.output_test_section'
+
+  it 'makes sure parsed and re-outputted example matches original example' do
+    # directly load the example file
+    direct_to_file = YAML.load_file(File.join(Rails.root, 'dryad-config-example', 'app_config.yml'))
+
+    # outputs the YAML and re-parses it
+    yaml_text = YamlHelper.output_test_section(example_filename: 'app_config.yml')
+    manipulated_yaml = YAML.safe_load(yaml_text)
+
+    # see if the two match, they should
+    expect(direct_to_file['test']['old_dryad_access_token']).to eq(manipulated_yaml['test']['old_dryad_access_token'])
+  end
+
+  it 'eliminates the --- at top of the yaml file since not appropriate for dropping in the middle' do
+    yaml_text = YamlHelper.output_test_section(example_filename: 'app_config.yml')
+    expect(yaml_text).not_to include('---')
+  end
+
+  it 'parses dynamic ERB stuff in original file as necessary' do
+    ENV['SOLR_URL'] = 'my_test_catfood'
+    # blacklight_yml has dynamic templating for this environment variable
+    yaml_text = YamlHelper.output_test_section(example_filename: 'blacklight.yml')
+    expect(yaml_text).to include('my_test_catfood')
+    ENV['SOLR_URL'] = nil
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/support/solr.rb
+++ b/spec/support/solr.rb
@@ -9,7 +9,7 @@ class SolrInstance
 
   SOLR_VERSION = '5.2.1'.freeze
   CONF_DIR = 'spec/config/solr/conf'.freeze
-  BLACKLIGHT_YML = 'dryad-config-example/blacklight.yml'.freeze
+  BLACKLIGHT_YML = 'config/blacklight.yml'.freeze # this setting is just used for testing, only
   COLLECTION_NAME = 'geoblacklight'.freeze
 
   def initialize
@@ -91,8 +91,10 @@ class SolrInstance
 
   def config
     @config ||= begin
-      # apparently have to do the true to enable aliases with safe_load
-      blacklight_config = YAML.safe_load(File.read(BLACKLIGHT_YML), [], [], true)['test']
+      # rubocop:disable Security/YAMLLoad
+      blacklight_config = YAML.load(ERB.new(File.read(File.join(Rails.root, SolrInstance::BLACKLIGHT_YML))).result)['test']
+      # rubocop:enable Security/YAMLLoad
+      # YAML.load(File.read(BLACKLIGHT_YML))['test']
       solr_uri = URI.parse(blacklight_config['url'])
       {
         port: solr_uri.port,

--- a/spec/support/solr.rb
+++ b/spec/support/solr.rb
@@ -92,7 +92,11 @@ class SolrInstance
   def config
     @config ||= begin
       # apparently have to do the true to enable aliases with safe_load
-      blacklight_config = YAML.safe_load(File.read(BLACKLIGHT_YML), [], [], true)['test']
+      # rubocop:disabledd Lint/Debugger: Remove debugger entry point byebug
+      # byebug
+      # rubocop:enabledd Lint/Debugger: Remove debugger entry point byebug
+      blacklight_config = YAML.safe_load(ERB.new(File.read(BLACKLIGHT_YML)).result, [], [], true)['test']
+      # blacklight_config = YAML.safe_load(File.read(BLACKLIGHT_YML), [], [], true)['test']
       solr_uri = URI.parse(blacklight_config['url'])
       {
         port: solr_uri.port,

--- a/spec/support/solr.rb
+++ b/spec/support/solr.rb
@@ -9,7 +9,7 @@ class SolrInstance
 
   SOLR_VERSION = '5.2.1'.freeze
   CONF_DIR = 'spec/config/solr/conf'.freeze
-  BLACKLIGHT_YML = 'config/blacklight.yml'.freeze
+  BLACKLIGHT_YML = 'dryad-config-example/blacklight.yml'.freeze
   COLLECTION_NAME = 'geoblacklight'.freeze
 
   def initialize
@@ -92,11 +92,7 @@ class SolrInstance
   def config
     @config ||= begin
       # apparently have to do the true to enable aliases with safe_load
-      # rubocop:disabledd Lint/Debugger: Remove debugger entry point byebug
-      # byebug
-      # rubocop:enabledd Lint/Debugger: Remove debugger entry point byebug
-      blacklight_config = YAML.safe_load(ERB.new(File.read(BLACKLIGHT_YML)).result, [], [], true)['test']
-      # blacklight_config = YAML.safe_load(File.read(BLACKLIGHT_YML), [], [], true)['test']
+      blacklight_config = YAML.safe_load(File.read(BLACKLIGHT_YML), [], [], true)['test']
       solr_uri = URI.parse(blacklight_config['url'])
       {
         port: solr_uri.port,


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/287 for an explanation of this problem.

This merges across **all 3 repos.**  I've added a test for the method that loads the dynamically inserted test environment information into yml files.  I couldn't get database.yml to substitute, but I think I got most of the rest and I'm not sure the database.yml is so much of a problem.