### PR TITLE
Mocked new ORCID endpoint

### DIFF
--- a/spec/factories/stash_datacite/affiliations.rb
+++ b/spec/factories/stash_datacite/affiliations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
 
   factory :affiliation, class: StashDatacite::Affiliation do
-    long_name { Faker::Educator.university }
+    long_name { Faker::Lorem.unique.word }
   end
 
 end

--- a/spec/features/stash_datacite/affiliation_autofill_spec.rb
+++ b/spec/features/stash_datacite/affiliation_autofill_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'AffiliationAutofill', type: :feature do
     it 'sets the ROR id when user selects an option', js: true do
       fill_in 'author[affiliation][long_name]', with: 'Testing'
       first('.ui-menu-item-wrapper', wait: 5).click
-      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('https://ror.org/TEST')
+      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('https://ror.org/TEST2')
     end
 
     it 'allows entries that are not registered with ROR', js: true do

--- a/spec/features/stash_datacite/new_dataset_spec.rb
+++ b/spec/features/stash_datacite/new_dataset_spec.rb
@@ -103,6 +103,7 @@ RSpec.feature 'NewDataset', type: :feature do
       waiver_country = Faker::Address.country
       waiver_university = Faker::Educator.university
       stub_ror_id_lookup(university: waiver_university, country: waiver_country)
+      stub_ror_name_lookup(name: waiver_university)
       allow_any_instance_of(StashDatacite::Affiliation).to receive(:fee_waiver_countries).and_return([waiver_country])
 
       # ##############################

--- a/spec/features/stash_discovery/solr_sanitization_spec.rb
+++ b/spec/features/stash_discovery/solr_sanitization_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'SolrSanitization', type: :feature do
     # Start Solr - shutdown is handled globally when all tests have finished
     # SolrInstance.instance
     # doc = YAML.load(ERB.new(File.read(File.join(Rails.root, SolrInstance::BLACKLIGHT_YML))).result)
-    # rubocop:enable Security/YAMLLoad
     # @solr = RSolr.connect(url: doc['test']['url'])
 
     # @uuid = Faker::Crypto.sha1

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.feature 'CurationActivity', type: :feature do
 
   include Mocks::Stripe
+  include Mocks::Ror
 
   # TODO: This should probably be defined in routes.rb and have appropriate helpers
   let(:dashboard_path) { '/stash/ds_admin' }
@@ -37,6 +38,7 @@ RSpec.feature 'CurationActivity', type: :feature do
 
       before(:each) do
         mock_stripe!
+        mock_ror!
         # Create a user, identifier and 2 resources for each tenant
         %w[ucop dryad].each do |tenant|
           user = create(:user, tenant_id: tenant)
@@ -65,6 +67,7 @@ RSpec.feature 'CurationActivity', type: :feature do
 
       before(:each) do
         mock_stripe!
+        mock_ror!
         create(:resource, user: create(:user, tenant_id: 'ucop'), identifier: create(:identifier))
         sign_in(create(:user, role: 'admin', tenant_id: 'ucop'))
       end

--- a/spec/features/stash_engine/migrate_data_spec.rb
+++ b/spec/features/stash_engine/migrate_data_spec.rb
@@ -4,9 +4,11 @@ require 'rails_helper'
 RSpec.feature 'MigrateData', type: :feature do
 
   include Mocks::RSolr
+  include Mocks::Ror
 
   before(:each) do
     mock_solr!
+    mock_ror!
     @user = create(:user, migration_token: Faker::Lorem.word)
     create(:resource, :submitted, user: @user, identifier: create(:identifier))
     sign_in(@user)

--- a/spec/mocks/omniauth.rb
+++ b/spec/mocks/omniauth.rb
@@ -30,6 +30,20 @@ module Mocks
             'User-Agent' => /.*/
           }
         ).to_return(status: 200, body: Mocks::Orcid.email_response(user).to_json, headers: {})
+
+
+      # https://api.sandbox.orcid.org/v2.1/5441f05582ea0983f9ad8b683127e6e6/email
+      stub_request(:get, %r{api\.sandbox\.orcid\.org/.*/employments})
+        .with(
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip, deflate',
+            'Authorization' => /Bearer .*/,
+            'Content-Type' => 'application/vnd.orcid+json',
+            'Host' => 'api.sandbox.orcid.org',
+            'User-Agent' => /.*/
+          }
+        ).to_return(status: 200, body: Mocks::Orcid.employment_response(user).to_json, headers: {})
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/spec/mocks/omniauth.rb
+++ b/spec/mocks/omniauth.rb
@@ -13,6 +13,7 @@ module Mocks
     end
 
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def mock_orcid!(user)
       # Mocks the Omniauth response from ORCID
       raise 'No tenant with id "localhost"; did you run travis-prep.sh?' unless StashEngine::Tenant.exists?('localhost')
@@ -31,7 +32,6 @@ module Mocks
           }
         ).to_return(status: 200, body: Mocks::Orcid.email_response(user).to_json, headers: {})
 
-
       # https://api.sandbox.orcid.org/v2.1/5441f05582ea0983f9ad8b683127e6e6/email
       stub_request(:get, %r{api\.sandbox\.orcid\.org/.*/employments})
         .with(
@@ -46,6 +46,7 @@ module Mocks
         ).to_return(status: 200, body: Mocks::Orcid.employment_response(user).to_json, headers: {})
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
   end
 

--- a/spec/mocks/orcid.rb
+++ b/spec/mocks/orcid.rb
@@ -41,6 +41,14 @@ module Mocks
         }
       end
 
+      def employment_response(user)
+        {
+          'employment-summary': [
+            { 'organization': user.present? && user.affiliation.present? ? user.affiliation.long_name : Faker::Educator.university }
+          ]
+        }
+      end
+
     end
 
   end

--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -3,8 +3,8 @@ module Mocks
   module Ror
 
     def mock_ror!(user = nil)
-      stub_ror_name_lookup(name: user&.affiliation&.long_name)
-      stub_ror_id_lookup(university: user&.affiliation&.long_name)
+      stub_ror_name_lookup(name: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
+      stub_ror_id_lookup(university: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -2,13 +2,13 @@ module Mocks
 
   module Ror
 
-    def mock_ror!
-      stub_ror_name_lookup
-      stub_ror_id_lookup
+    def mock_ror!(user = nil)
+      stub_ror_name_lookup(name: user&.affiliation&.long_name)
+      stub_ror_id_lookup(university: user&.affiliation&.long_name)
     end
 
     # rubocop:disable Metrics/MethodLength
-    def stub_ror_id_lookup(university: 'University of Testing', country: 'United States of America')
+    def stub_ror_id_lookup(university: Faker::Educator.university, country: 'United States of America')
       # Mock a request for a specific ROR Organization
       stub_request(:get, %r{api\.ror\.org/organizations/.+})
         .with(
@@ -29,7 +29,7 @@ module Mocks
         }.to_json, headers: { 'Content-Type' => 'application/json' })
     end
 
-    def stub_ror_name_lookup
+    def stub_ror_name_lookup(name: Faker::Educator.university)
       # Mock a ROR Organization query
       stub_request(:get, %r{api\.ror\.org/organizations\?query(.\s)*})
         .with(
@@ -42,13 +42,13 @@ module Mocks
           'items': [
             {
               'id': 'https://ror.org/TEST',
-              'name': 'University of Testing',
+              'name': name,
               'types': ['Education'],
               'links': ['http://example.org/test'],
               'aliases': ['testing'],
               'acronyms': ['TST'],
               'wikipedia_url': 'http://example.org/wikipedia/wiki/test',
-              'labels': [{ 'iso639': 'id', 'label': 'University of Testing' }],
+              'labels': [{ 'iso639': 'id', 'label': name }],
               'country': { 'country_code': 'US', 'country_name': 'United States of America' },
               'external_ids': { 'GRID': { 'prefered': 'grid.test.123' } }
             },

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -58,6 +58,7 @@ module StashApi
     describe '#index' do
 
       before(:each) do
+        mock_ror!
         # these tests are very similar to tests in the model controller for identifier for querying this scope
         @user1 = create(:user, tenant_id: 'ucop', role: nil)
         @user2 = create(:user, tenant_id: 'ucop', role: 'admin')

--- a/spec/support/helpers/session_helper.rb
+++ b/spec/support/helpers/session_helper.rb
@@ -1,6 +1,7 @@
 module SessionsHelper
 
   include Mocks::Omniauth
+  include Mocks::Ror
 
   def sign_in(user = create(:user), with_shib = false)
     sign_out if have_text('Logout')
@@ -19,8 +20,9 @@ module SessionsHelper
   end
 
   def sign_in_as_user(user, with_shib)
-    OmniAuth.config.test_mode = true
     mock_orcid!(user)
+    mock_ror!
+    OmniAuth.config.test_mode = true
     visit root_path
     click_link 'Login'
     click_link 'Login or create your ORCID iD'

--- a/spec/support/helpers/session_helper.rb
+++ b/spec/support/helpers/session_helper.rb
@@ -19,6 +19,7 @@ module SessionsHelper
     visit stash_url_helpers.sessions_destroy_path
   end
 
+  # rubocop:disable Metrics/MethodLength
   def sign_in_as_user(user, with_shib)
     mock_orcid!(user)
     mock_ror!
@@ -36,5 +37,6 @@ module SessionsHelper
       click_link 'Continue to My Datasets'
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
 end


### PR DESCRIPTION
Mock for new call to grab employment info from ORCID
for ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/288

also needed to add a call to `mock_ror` in a few places to accommodate ROR lookup that happens after ORCID employment is retrieved