### PR TITLE
Making submissions queue

### DIFF
--- a/documentation/test_submission/make_records.rb
+++ b/documentation/test_submission/make_records.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+
+require 'rest-client'
+require 'json'
+require 'byebug'
+require 'faker'
+require 'securerandom'
+require 'fileutils'
+
+app_id = ''
+secret = ''
+email = ''
+
+domain_name = 'http://localhost:3000'
+response = RestClient.post "#{domain_name}/oauth/token", {
+    grant_type: 'client_credentials',
+    client_id: app_id,
+    client_secret: secret
+}
+token = JSON.parse(response)['access_token']
+
+
+
+headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{token}" }
+resp = RestClient.get "#{domain_name}/api/test", headers
+j = JSON.parse(resp)
+raise 'Invalid API connection' if j['user_id'].nil?
+puts "Logged in as #{j['user_id']}"
+
+
+PATCH_SUBMISSION = [{ "op": "replace", "path": "/versionStatus", "value": "submitted" }].to_json.freeze
+
+(1).upto(100) do |i|
+
+  puts "##{i}"
+  metadata_hash = {'title': Faker::Lorem.words(rand(10)+1).map(&:capitalize).join(" "),
+    'authors': [{'firstName': Faker::Name.first_name, 'lastName': Faker::Name.last_name, 'email': email, 'affiliation': Faker::University.name}],
+    'abstract': Faker::Lorem.paragraph }
+
+  puts "  creating ds w/ title: #{metadata_hash[:title]}"
+  # create new dataset with metadata
+  resp = RestClient.post "#{domain_name}/api/datasets", metadata_hash.to_json, headers
+  return_hash = JSON.parse(resp)
+  doi = return_hash['identifier']
+  doi_encoded = CGI.escape(doi)
+
+  puts "  creating file"
+  # create a file of random data
+  fn = "#{Faker::Name.first_name}.txt"
+  one_megabyte = 1_000_000
+  size = rand(50) + 1
+  File.open(fn, 'wb') do |f|
+    size.to_i.times { f.write( SecureRandom.random_bytes( one_megabyte ) ) }
+  end
+
+  puts "  uploading the file: #{fn}"
+  content_type = 'text/plain'
+  resp = RestClient.put(
+      "#{domain_name}/api/datasets/#{doi_encoded}/files/#{URI.escape(fn)}",
+      File.read(fn),
+      headers.merge({'Content-Type' => content_type})
+  )
+  return_hash = JSON.parse(resp)
+  raise 'Bad upload' if resp.code != 201
+
+  puts "  submitting the dataset"
+  # submit the dataset to the storage repository
+  resp = RestClient.patch(
+      "#{domain_name}/api/datasets/#{doi_encoded}",
+      PATCH_SUBMISSION,
+      headers.merge({'Content-Type' =>  'application/json-patch+json'})
+  )
+  raise 'Bad submission to the storage repository' if resp.code != 202
+
+  FileUtils.rm(fn)
+
+end

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -26,6 +26,7 @@ defaults: &DEFAULTS
     key: <REPLACE-ME>
     data_processing_charge: 12000 #charge in cents
   merritt_express_domain: dummy_domain.example.com
+  merritt_max_submission_threads: 1
   crossref_base_url: https://api.crossref.org
   crossref_mailto: test.dude@example.edu
   fee_waiver_countries:

--- a/spec/features/stash_engine/dataset_queuing_spec.rb
+++ b/spec/features/stash_engine/dataset_queuing_spec.rb
@@ -58,8 +58,8 @@ RSpec.feature 'DatasetQueuing', type: :feature do
     it 'should show queuing', js: true do
       visit '/stash/submission_queue'
       wait_for_ajax(15)
-      expect(page).to have_text('1 are currently processing from this server')
-      expect(page).to have_text('2 queued on this server')
+      expect(page).to have_content(/[01] are currently processing from this server/)
+      expect(page).to have_content(/[23] queued on this server/)
     end
 
     it 'should pause transfers', js: true do

--- a/spec/features/stash_engine/dataset_queuing_spec.rb
+++ b/spec/features/stash_engine/dataset_queuing_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.feature 'DatasetQueuing', type: :feature do
+
+  # include MerrittHelper
+  include DatasetHelper
+  include Mocks::Datacite
+  # include Mocks::Repository
+  include Mocks::SubmissionJob
+  include Mocks::RSolr
+  include Mocks::Ror
+  include Mocks::Stripe
+  include AjaxHelper
+
+  before(:each) do
+    # mock_repository!
+    # for this we don't want to mock the whole repository, but just the actual submission to Merritt that happens in
+    # the queue, Stash::Merritt::SubmissionJob.do_submit!
+    mock_submission_job!
+    mock_solr!
+    mock_ror!
+    mock_datacite!
+    mock_stripe!
+    @curator = create(:user, role: 'admin', tenant_id: 'dryad')
+    @author = create(:user, tenant_id: 'dryad', role: 'superuser')
+    @document_list = []
+  end
+
+  describe :submitting_quickly do
+
+    before(:each, js: true) do
+      ActionMailer::Base.deliveries = []
+      # Sign in and create a new dataset
+      sign_in(@author)
+      visit root_path
+      click_link 'My Datasets'
+      3.times do
+        start_new_dataset
+        fill_required_fields
+        navigate_to_review
+        check 'agree_to_license'
+        check 'agree_to_tos'
+        check 'agree_to_payment'
+        click_button 'submit_dataset'
+      end
+      @resource = StashEngine::Resource.where(user: @author).last
+    end
+
+    it 'should show queuing', js: true do
+      visit '/stash/submission_queue'
+      wait_for_ajax(15)
+      expect(page).to have_text('1 are currently processing from this server')
+      expect(page).to have_text('2 queued on this server')
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/mocks/repository.rb
+++ b/spec/mocks/repository.rb
@@ -17,7 +17,7 @@ module Mocks
     end
     # rubocop:enable Metrics/AbcSize
 
-    class Repository < Stash::Repo::Repository
+    class Repository < Stash::Merritt::Repository
 
     end
 

--- a/spec/mocks/submission_job.rb
+++ b/spec/mocks/submission_job.rb
@@ -8,9 +8,6 @@ module Mocks
     def mock_submission_job!
       allow_any_instance_of(Stash::Merritt::Repository).to receive(:download_uri_for).and_return(mint_id)
       allow_any_instance_of(Stash::Merritt::Repository).to receive(:update_uri_for).and_return(mint_id)
-      # allow_any_instance_of(Stash::Merritt::SubmissionJob).to receive(:'do_submit!').and_return(
-      #  Stash::Repo::SubmissionResult.success(resource_id: 1, request_desc: 'test description', message: 'Success')
-      # )
       Stash::Merritt::SubmissionJob.prepend(Mocks::SubmissionJob::MonkeyPatch) # a way to override this method
     end
 

--- a/spec/mocks/submission_job.rb
+++ b/spec/mocks/submission_job.rb
@@ -1,0 +1,24 @@
+module Mocks
+  module SubmissionJob
+
+    def mint_id
+      "doi:#{Faker::Pid.doi}"
+    end
+
+    def mock_submission_job!
+      allow_any_instance_of(Stash::Merritt::Repository).to receive(:download_uri_for).and_return(mint_id)
+      allow_any_instance_of(Stash::Merritt::Repository).to receive(:update_uri_for).and_return(mint_id)
+      # allow_any_instance_of(Stash::Merritt::SubmissionJob).to receive(:'do_submit!').and_return(
+      #  Stash::Repo::SubmissionResult.success(resource_id: 1, request_desc: 'test description', message: 'Success')
+      # )
+      Stash::Merritt::SubmissionJob.prepend(Mocks::SubmissionJob::MonkeyPatch) # a way to override this method
+    end
+
+    module MonkeyPatch
+      def do_submit!
+        sleep 30 # to simulate submission happening, this should be in background thread, so enjoy!
+        Stash::Repo::SubmissionResult.success(resource_id: resource_id, request_desc: description, message: 'Success')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the mega PR for ticket https://github.com/CDL-Dryad/dryad-product-roadmap/issues/302  .  It needs merging from all 3 repositories (dryad, stash, dryad-config).

The main thing is that this only submits a limited number of items to Merritt at a time and queues the rest to submit in pool of items.  If you feel like testing by submitting a bunch of random data to Merritt, then this will help you do it through our API.  https://github.com/CDL-Dryad/dryad/blob/submission-queue/documentation/test_submission/make_records.rb  (you need to fill in some keys and things you'll see at the top of the file).

There is also an administrator page at /stash/submission_queue for our own internal use.  This allows for stopping the submissions gracefully (wait for them to clear) and starting them again.  It also gives lots of information about them.

This turned out to be tricky to get right and be sure it was working right since the way it does the success Promise callback is weird.  It puts the success callbacks on the same queue internally that runs the actual submissions, so the status takes some time to update.

LMK if there are questions.


