### PR TITLE
Allow local_dev to use the same classes as dev but with reloading

### DIFF
--- a/config/environments/local_dev.rb
+++ b/config/environments/local_dev.rb
@@ -4,10 +4,10 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = true
+  config.eager_load = false
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
We need to switch `cache_classes` and `eager_load` to true for the development machine to prevent concurrency race conditions.

So to run things locally with class reloading enabled we needed a new environment called local_dev.  It's the same as dev but with these different settings.

Also changes in the config repo.