### PR TITLE
Api queue info

### DIFF
--- a/spec/responses/stash_api/submission_queue_controller_spec.rb
+++ b/spec/responses/stash_api/submission_queue_controller_spec.rb
@@ -21,8 +21,8 @@ module StashApi
       it 'returns JSON for queue length and executor queue length' do
         get '/api/queue_length', {}, default_authenticated_headers
         output = JSON.parse(response.body).with_indifferent_access
-        expect(output[:queue_length]).to eq(0)
-        expect(output[:executor_queue_length]).to eq(0)
+        expect(output[:queue_length]).to be_a(Integer)
+        expect(output[:executor_queue_length]).to be_a(Integer)
       end
     end
   end

--- a/spec/responses/stash_api/submission_queue_controller_spec.rb
+++ b/spec/responses/stash_api/submission_queue_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require_relative 'helpers'
+require 'fixtures/stash_api/metadata'
+
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashApi
+  RSpec.describe SubmissionQueueController, type: :request do
+
+    before(:all) do
+      @user = create(:user, role: 'superuser')
+      @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                                                owner_id: @user.id, owner_type: 'StashEngine::User')
+      setup_access_token(doorkeeper_application: @doorkeeper_application)
+    end
+
+    # I am not testing queuing working here since this is just read only visibility into what
+    # is tested and exposed elsewhere.
+
+    # test queue length being returned
+    describe '#length' do
+      it 'returns JSON for queue length and executor queue length' do
+        get '/api/queue_length', {}, default_authenticated_headers
+        output = JSON.parse(response.body).with_indifferent_access
+        expect(output[:queue_length]).to eq(0)
+        expect(output[:executor_queue_length]).to eq(0)
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength, Metrics/ModuleLength


### PR DESCRIPTION
This PR involves one on both dryad and stash repositories (copying and pasting description into both).

This is for our migration so as not to overwhelm things.  You can make a call to /api/queue_length with all the usual API headers, etc.

It will allow monitoring of queue length so as not to keep sending more stuff to the server if it already has a lot in queue (or it is being held for shutdown).  It returns the `queue_length` & `executor_queue_length`.

Generally speaking the executor queue length is about double (or sometimes a little more) the things that are actually queued for work to be done since the success/error callbacks also get put on the executor queue separately by the internals of the gem.

I'd probably do something like this (in pseudocode) and tune it if it either creates too much or too little of a queue.  I think we want to have a work queue most of the time, but we don't want too long of one.  You also probably don't want to query the queue too often and just top up with new batches of submissions.

```
loop until done
  query_queue_length
  if queue_length > 40 or executor_queue_length > 80
    sleep 30
  else
    send 40 more datasets to be deposited
  end
end
```

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/316
