### PR TITLE
Response test -- Retain the original publication date

### DIFF
--- a/spec/features/stash_discovery/solr_sanitization_spec.rb
+++ b/spec/features/stash_discovery/solr_sanitization_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'SolrSanitization', type: :feature do
     # Start Solr - shutdown is handled globally when all tests have finished
     # SolrInstance.instance
     # doc = YAML.load(ERB.new(File.read(File.join(Rails.root, SolrInstance::BLACKLIGHT_YML))).result)
-    # rubocop:enable Security/YAMLLoad
+
     # @solr = RSolr.connect(url: doc['test']['url'])
 
     # @uuid = Faker::Crypto.sha1

--- a/spec/fixtures/stash_api/curation_metadata.rb
+++ b/spec/fixtures/stash_api/curation_metadata.rb
@@ -1,0 +1,27 @@
+require 'faker'
+require 'json'
+module Fixtures
+  module StashApi
+    class CurationMetadata
+
+      def initialize
+        @curation_metadata = ActiveSupport::HashWithIndifferentAccess.new
+        @curation_metadata[:status] = 'published'
+        add_note
+      end
+
+      def hash
+        @curation_metadata.with_indifferent_access
+      end
+
+      def json
+        @curation_metadata.to_json
+      end
+
+      def add_note
+        @curation_metadata.merge!(note: Faker::Lorem.paragraph)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Add a response test for https://github.com/CDL-Dryad/stash/pull/173.

As a side effect, this does some basic testing that curation activities are created when submitted through the API.