### PR TITLE
I'm adding a rake command just to clear database of datasets & dependent objects

### DIFF
--- a/lib/tasks/app_data.rake
+++ b/lib/tasks/app_data.rake
@@ -1,6 +1,13 @@
 require_relative '../../script/clear_data'
 namespace :app_data do
   desc 'Clear just the identifiers and dependent items from database and clear out SOLR'
+  task clear_data: :environment do
+    puts "Are you sure you want to clear the data in the environment #{Rails.env}?  (Type 'yes' to proceed.)"
+    response = STDIN.gets
+    ClearData.clear_data if response.strip.casecmp('YES').zero? && Rails.env != 'production'
+  end
+
+  desc 'Clear just the identifiers and dependent items from database and DO NOT clear out SOLR'
   task clear_datasets: :environment do
     puts "Are you sure you want to clear the data in the environment #{Rails.env}?  (Type 'yes' to proceed.)"
     response = STDIN.gets

--- a/script/clear_data.rb
+++ b/script/clear_data.rb
@@ -1,11 +1,15 @@
 module ClearData
 
+  def self.clear_data
+    clear_datasets
+    clear_solr
+  end
+
   def self.clear_datasets
     StashEngine::Identifier.all.each do |iden|
       puts "Destroying #{iden.identifier}"
       iden.destroy
     end
-    clear_solr
   end
 
   def self.clear_solr


### PR DESCRIPTION
I've added another task to these. clear_data attempts to clear datasets out of BOTH the database and SOLR.  clear_datasets just attempts to just clear the datasets.  These are really for testing environments.

For clearing out the **migration** environment, I'd just clear the datasets from the database and not clear solr.  Migration doesn't currently have its own SOLR environment, so clearing the associated SOLR would clear stage (not what you want).

See our confluence page at https://confluence.ucop.edu/display/Stash/Dryad+Operations#DryadOperations-ClearingalldatafromDBandSOLRforafreshstart(onlyfordevelopment/testing!!!) for more information.

