### PR TITLE
Add ROR heartbeat check stub to Rspec mocks

### DIFF
--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -7,6 +7,17 @@ module Mocks
       stub_ror_id_lookup(university: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
     end
 
+    def stub_ror_heartbeat_check
+      stub_request(:get, "https://api.ror.org/heartbeat")
+        .with(
+           headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent'=>'Ruby'
+           })
+        .to_return(status: 200, body: "", headers: {})
+    end
+
     # rubocop:disable Metrics/MethodLength
     def stub_ror_id_lookup(university: Faker::Educator.university, country: 'United States of America')
       # Mock a request for a specific ROR Organization

--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -3,6 +3,7 @@ module Mocks
   module Ror
 
     def mock_ror!(user = nil)
+      stub_ror_heartbeat_check
       stub_ror_name_lookup(name: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
       stub_ror_id_lookup(university: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
     end

--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -9,14 +9,15 @@ module Mocks
     end
 
     def stub_ror_heartbeat_check
-      stub_request(:get, "https://api.ror.org/heartbeat")
+      stub_request(:get, 'https://api.ror.org/heartbeat')
         .with(
-           headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent'=>'Ruby'
-           })
-        .to_return(status: 200, body: "", headers: {})
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 200, body: '', headers: {})
     end
 
     # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Added the new ROR heartbeat check to the Rspec mocks.

This goes with the corresponding PR in the stash repo that provides support for the external dependency dashboard