### PR TITLE
Api security part 1

### DIFF
--- a/spec/mocks/curation_activity.rb
+++ b/spec/mocks/curation_activity.rb
@@ -2,6 +2,7 @@ module Mocks
 
   module CurationActivity
 
+    # rubocop:disable Metrics/AbcSize
     def neuter_curation_callbacks!
       # These callbacks cause constant grief when you're just trying to set up curation states in order to
       # do things like test dataset visibility.  Mostly we don't want these running in tests unless we're testing that
@@ -12,5 +13,6 @@ module Mocks
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_author).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_orcid_invitations).and_return(true)
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/spec/mocks/curation_activity.rb
+++ b/spec/mocks/curation_activity.rb
@@ -1,0 +1,16 @@
+module Mocks
+
+  module CurationActivity
+
+    def neuter_curation_callbacks!
+      # These callbacks cause constant grief when you're just trying to set up curation states in order to
+      # do things like test dataset visibility.  Mostly we don't want these running in tests unless we're testing that
+      # callback explicitly.
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:submit_to_datacite).and_return(true)
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:update_solr).and_return(true)
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:submit_to_stripe).and_return(true)
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_author).and_return(true)
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_orcid_invitations).and_return(true)
+    end
+  end
+end

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -12,6 +12,7 @@ module StashApi
     include Mocks::Ror
     include Mocks::RSolr
     include Mocks::Stripe
+    include Mocks::CurationActivity
 
     before(:all) do
       @user = create(:user, role: 'superuser')
@@ -23,9 +24,8 @@ module StashApi
     # test creation of a new dataset
     describe '#create' do
       before(:each) do
+        neuter_curation_callbacks!
         mock_ror!
-        mock_solr!
-        mock_stripe!
         @meta = Fixtures::StashApi::Metadata.new
         @meta.make_minimal
       end
@@ -104,6 +104,7 @@ module StashApi
 
       before(:each) do
         mock_ror!
+        neuter_curation_callbacks!
         # these tests are very similar to tests in the model controller for identifier for querying this scope
         @user1 = create(:user, tenant_id: 'ucop', role: nil)
         @user2 = create(:user, tenant_id: 'ucop', role: 'admin')

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -3,6 +3,7 @@ require 'uri'
 require_relative 'helpers'
 require 'fixtures/stash_api/metadata'
 require 'fixtures/stash_api/curation_metadata'
+require 'cgi'
 
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
 # rubocop:disable Metrics/BlockLength, Metrics/ModuleLength
@@ -124,42 +125,42 @@ module StashApi
                       create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id, identifier_id: @identifiers[6].id),
                       create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id, identifier_id: @identifiers[7].id)]
 
-        @curation_activities = [[create(:curation_activity_no_callbacks, resource: @resources[0], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[0], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[0], status: 'published')]]
+        @curation_activities = [[create(:curation_activity, resource: @resources[0], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[0], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[0], status: 'published')]]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[1], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[1], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[1], status: 'embargoed')]
+        @curation_activities << [create(:curation_activity, resource: @resources[1], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[1], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[1], status: 'embargoed')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[2], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[2], status: 'curation')]
+        @curation_activities << [create(:curation_activity, resource: @resources[2], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[2], status: 'curation')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[3], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[3], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[3], status: 'action_required')]
+        @curation_activities << [create(:curation_activity, resource: @resources[3], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[3], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[3], status: 'action_required')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[4], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[4], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[4], status: 'published')]
+        @curation_activities << [create(:curation_activity, resource: @resources[4], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[4], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[4], status: 'published')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[5], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[5], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[5], status: 'embargoed')]
+        @curation_activities << [create(:curation_activity, resource: @resources[5], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[5], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[5], status: 'embargoed')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[6], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[6], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[6], status: 'withdrawn')]
+        @curation_activities << [create(:curation_activity, resource: @resources[6], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[6], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[6], status: 'withdrawn')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[7], status: 'in_progress')]
+        @curation_activities << [create(:curation_activity, resource: @resources[7], status: 'in_progress')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[8], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[8], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[8], status: 'published')]
+        @curation_activities << [create(:curation_activity, resource: @resources[8], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[8], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[8], status: 'published')]
 
-        @curation_activities << [create(:curation_activity_no_callbacks, resource: @resources[9], status: 'in_progress'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[9], status: 'curation'),
-                                 create(:curation_activity_no_callbacks, resource: @resources[9], status: 'embargoed')]
+        @curation_activities << [create(:curation_activity, resource: @resources[9], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[9], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[9], status: 'embargoed')]
 
         # 5 public datasets
         #
@@ -206,7 +207,7 @@ module StashApi
           # make identifier[0] have a second version that isn't publicly viewable yet
           @curation_activities[1][2].destroy
           # versions not getting set correctly for these two resources for some reason
-          @resources[1].stash_version.update(version: 1)
+          @resources[0].stash_version.update(version: 1)
           @resources[1].stash_version.update(version: 2)
         end
 
@@ -256,6 +257,60 @@ module StashApi
         end
 
       end
+    end
+
+    describe '#show' do
+
+      before(:each) do
+        mock_ror!
+        neuter_curation_callbacks!
+
+        @tenant_ids = StashEngine::Tenant.all.map(&:tenant_id)
+
+        # I think @user is created for use with doorkeeper already
+        @user2 = create(:user, tenant_id: @tenant_ids.first, role: 'user')
+
+        @identifier = create(:identifier)
+
+        @resources = [create(:resource, user_id: @user2.id, tenant_id: @user.tenant_id, identifier_id: @identifier.id),
+                      create(:resource, user_id: @user2.id, tenant_id: @user.tenant_id, identifier_id: @identifier.id)]
+
+        @curation_activities = [[create(:curation_activity, resource: @resources[0], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[0], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[0], status: 'published')]]
+
+        @curation_activities << [create(:curation_activity, resource: @resources[1], status: 'in_progress'),
+                                 create(:curation_activity, resource: @resources[1], status: 'curation')]
+
+        # set versions correctly seems not correctly working unless created another way.
+        @resources[0].stash_version.update(version: 1)
+        @resources[1].stash_version.update(version: 2)
+      end
+
+      it 'shows a public record for a created indentifier/resource' do
+        get "/api/datasets/#{CGI.escape(@identifier.to_s)}", {}, default_json_headers # not logged in
+        hsh = response_body_hash
+        expect(hsh['versionNumber']).to eq(1)
+        expect(hsh['title']).to eq(@resources[0].title)
+      end
+
+      it 'shows the private record for superuser' do
+        get "/api/datasets/#{CGI.escape(@identifier.to_s)}", {}, default_authenticated_headers
+        hsh = response_body_hash
+        expect(hsh['versionNumber']).to eq(2)
+        expect(hsh['title']).to eq(@resources[1].title)
+      end
+
+      it 'shows the private record for the owner' do
+        @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                                                   owner_id: @user2.id, owner_type: 'StashEngine::User')
+        access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
+        get "/api/datasets/#{CGI.escape(@identifier.to_s)}", {}, default_json_headers.merge('Authorization' => "Bearer #{access_token}")
+        hsh = response_body_hash
+        expect(hsh['versionNumber']).to eq(2)
+        expect(hsh['title']).to eq(@resources[1].title)
+      end
+
     end
   end
 end

--- a/spec/responses/stash_api/general_controller_spec.rb
+++ b/spec/responses/stash_api/general_controller_spec.rb
@@ -5,47 +5,11 @@ require 'byebug'
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
 module StashApi
   RSpec.describe GeneralController, type: :request do
-
-    include Mocks::CurationActivity
-
     before(:all) do
       @user = create(:user, role: 'superuser')
       @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                 owner_id: @user.id, owner_type: 'StashEngine::User')
       setup_access_token(doorkeeper_application: @doorkeeper_application)
-    end
-
-    # this is the general index of datasets
-    describe '#index' do
-
-      before(:each) do
-        neuter_curation_callbacks!
-
-        @users = Array.new(5) { create(:user) }
-        @identifiers = []
-
-        0.upto(4) do |i|
-          @identifiers << create(:identifier) do |iden|
-            @res = iden.resources.create(attributes_for(:resource, :submitted, user_id: @users[i].id))
-            @res.descriptions.create(attributes_for(:description))
-            @res.authors.create(attributes_for(:author, author_first_name: @users[i].first_name,
-                                               author_last_name: @users[i].last_name,
-                                               author_email: @users[i].email))
-          end
-        end
-        @res = @identifiers.map { |id| id.resources.first }
-        @res[0].curation_activities.create(attributes_for(:curation_activity, :published))
-        @res[1].curation_activities.create(attributes_for(:curation_activity, :embargoed))
-        @res[2].curation_activities.create(attributes_for(:curation_activity, :submitted))
-        @res[3].curation_activities.create(attributes_for(:curation_activity, :action_required))
-        @res[4].curation_activities.create(attributes_for(:curation_activity, :curation))
-        byebug
-      end
-
-      it 'is a placeholder for now' do
-        expect(true).to eql(true)
-      end
-
     end
 
     describe '#test' do
@@ -60,6 +24,14 @@ module StashApi
         response_code = post '/api/test', nil, default_json_headers
         expect(response_code).to eq(401) # unauthorized
         expect(/invalid_token/).to match(response.headers['WWW-Authenticate'])
+      end
+    end
+
+    describe '#index' do
+      it 'has a HATEOAS link to the main entry into API, the datasets list' do
+        get '/api/', {}, default_json_headers
+        hsh = response_body_hash
+        expect(hsh['_links']['stash:datasets']['href']).to eql('/api/datasets')
       end
     end
   end

--- a/spec/responses/stash_api/general_controller_spec.rb
+++ b/spec/responses/stash_api/general_controller_spec.rb
@@ -1,15 +1,64 @@
 require 'rails_helper'
 require_relative 'helpers'
+require 'byebug'
 
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
 module StashApi
   RSpec.describe GeneralController, type: :request do
+
+    include Mocks::Datacite
+    include Mocks::RSolr
 
     before(:all) do
       @user = create(:user, role: 'superuser')
       @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                 owner_id: @user.id, owner_type: 'StashEngine::User')
       setup_access_token(doorkeeper_application: @doorkeeper_application)
+    end
+
+    # this is the general index of datasets
+    describe '#index' do
+
+      before(:each) do
+        mock_solr!
+        mock_datacite!
+        allow_any_instance_of(StashEngine::Resource).to receive(:submit_to_solr).and_return(true)
+        stub_request(:post, 'http://127.0.0.1:8983/solr/geoblacklight/update?wt=ruby')
+          .with(
+            body: /.+/,
+            headers: {
+              'Content-Type' => 'text/xml'
+            }
+          )
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      before(:all) do
+        @users = Array.new(5) { create(:user) }
+        @identifiers = []
+
+        0.upto(4) do |i|
+          @identifiers << create(:identifier) do |iden|
+            @res = iden.resources.create(attributes_for(:resource, :submitted, user_id: @users[i].id))
+            @res.descriptions.create(attributes_for(:description))
+            @res.authors.create(attributes_for(:author, author_first_name: @users[i].first_name,
+                                                        author_last_name: @users[i].last_name,
+                                                        author_email: @users[i].email))
+          end
+        end
+        @res = @identifiers.map { |id| id.resources.first }
+        @res[0].curation_activities.create(attributes_for(:curation_activity, :published))
+        @res[1].curation_activities.create(attributes_for(:curation_activity, :embargoed))
+        @res[2].curation_activities.create(attributes_for(:curation_activity, :submitted))
+        @res[3].curation_activities.create(attributes_for(:curation_activity, :action_required))
+        @res[4].curation_activities.create(attributes_for(:curation_activity, :curation))
+        byebug
+      end
+
+      it 'is a placeholder for now' do
+        expect(true).to eql(true)
+      end
+
     end
 
     describe '#test' do

--- a/spec/responses/stash_api/general_controller_spec.rb
+++ b/spec/responses/stash_api/general_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require_relative 'helpers'
 require 'byebug'
 
+# rubocop:disable Metrics/BlockLength
+
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
 module StashApi
   RSpec.describe GeneralController, type: :request do
@@ -36,3 +38,4 @@ module StashApi
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/responses/stash_api/general_controller_spec.rb
+++ b/spec/responses/stash_api/general_controller_spec.rb
@@ -6,8 +6,7 @@ require 'byebug'
 module StashApi
   RSpec.describe GeneralController, type: :request do
 
-    include Mocks::Datacite
-    include Mocks::RSolr
+    include Mocks::CurationActivity
 
     before(:all) do
       @user = create(:user, role: 'superuser')
@@ -20,20 +19,8 @@ module StashApi
     describe '#index' do
 
       before(:each) do
-        mock_solr!
-        mock_datacite!
-        allow_any_instance_of(StashEngine::Resource).to receive(:submit_to_solr).and_return(true)
-        stub_request(:post, 'http://127.0.0.1:8983/solr/geoblacklight/update?wt=ruby')
-          .with(
-            body: /.+/,
-            headers: {
-              'Content-Type' => 'text/xml'
-            }
-          )
-          .to_return(status: 200, body: '', headers: {})
-      end
+        neuter_curation_callbacks!
 
-      before(:all) do
         @users = Array.new(5) { create(:user) }
         @identifiers = []
 
@@ -42,8 +29,8 @@ module StashApi
             @res = iden.resources.create(attributes_for(:resource, :submitted, user_id: @users[i].id))
             @res.descriptions.create(attributes_for(:description))
             @res.authors.create(attributes_for(:author, author_first_name: @users[i].first_name,
-                                                        author_last_name: @users[i].last_name,
-                                                        author_email: @users[i].email))
+                                               author_last_name: @users[i].last_name,
+                                               author_email: @users[i].email))
           end
         end
         @res = @identifiers.map { |id| id.resources.first }

--- a/spec/responses/stash_api/helpers.rb
+++ b/spec/responses/stash_api/helpers.rb
@@ -7,11 +7,15 @@ module Helpers
     config.include Helpers
   end
 
-  def setup_access_token(doorkeeper_application:)
+  def get_access_token(doorkeeper_application:)
     post '/oauth/token',
          { grant_type: 'client_credentials', client_id: doorkeeper_application.uid, client_secret: doorkeeper_application.secret },
          default_json_headers.merge('Content-type' => 'application/x-www-form-urlencoded;charset=UTF-8')
-    @access_token = response_body_hash[:access_token]
+    response_body_hash[:access_token]
+  end
+
+  def setup_access_token(doorkeeper_application:)
+    @access_token = get_access_token(doorkeeper_application: doorkeeper_application)
   end
 
   def response_body_hash


### PR DESCRIPTION
This is for the first part of the ticket at https://github.com/CDL-Dryad/dryad-product-roadmap/issues/301  (basically the parts I've checked).  It's a PR across both Dryad and Stash repos.

The ticket describes it pretty well.

Mainly, any calls for generating dataset display structure for the API (Dataset.new) needs to take a user (or nil for public) because the dataset by default displays the latest version of the metadata that is available for viewing.  Different users will see different latest versions based on their ownership or roles vs the public.

The latest_viewable_resource takes care of most of this, but I needed to be sure the Dataset.new display setup was taking the user so it would calculate the display right.  Also had to change tests and add tests for it, which took some time.

