### PR TITLE
updated text of expected errror message

### DIFF
--- a/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
+++ b/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature 'Populate manuscript metadata from outside source', type: :feature
       doi = 'scabs'
       fill_crossref_info(name: journal, doi: doi)
       click_button 'Import Article Metadata'
-      expect(page.find('div#population-warnings')).to have_content("We couldn't retrieve information from CrossRef about this DOI", wait: 15)
+      expect(page.find('div#population-warnings')).to have_content("We couldn't obtain information from CrossRef about this DOI", wait: 15)
     end
   end
 end


### PR DESCRIPTION
Fixes issue with a change to the error message returned by the publication_controller when Crossref could not find a match for the DOI provided by the user.