### PR TITLE
Changes for files api, downloading files and tests for security

### DIFF
--- a/spec/factories/stash_engine/file_uploads.rb
+++ b/spec/factories/stash_engine/file_uploads.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     upload_file_name { ::File.basename(Faker::File.file_name) }
     upload_content_type { Faker::File.mime_type }
-    upload_file_size { Faker::Number.between(1, 100000000) }
+    upload_file_size { Faker::Number.between(1, 100_000_000) }
     temp_file_path { Faker::File.file_name }
     file_state { 'created' }
   end

--- a/spec/factories/stash_engine/file_uploads.rb
+++ b/spec/factories/stash_engine/file_uploads.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+
+  factory :file_upload, class: StashEngine::FileUpload do
+    resource
+
+    upload_file_name { ::File.basename(Faker::File.file_name) }
+    upload_content_type { Faker::File.mime_type }
+    upload_file_size { Faker::Number.between(1, 100000000) }
+    temp_file_path { Faker::File.file_name }
+    file_state { 'created' }
+  end
+end

--- a/spec/responses/stash_api/files_controller_spec.rb
+++ b/spec/responses/stash_api/files_controller_spec.rb
@@ -231,6 +231,11 @@ module StashApi
         response_code = delete "/api/files/#{@files[1].first.id}", {}, default_authenticated_headers
         expect(response_code).to eq(401)
       end
+
+      it "blocks destroying file if the version isn't being edited" do
+        response_code = delete "/api/files/#{@files[0].first.id}", {}, default_authenticated_headers
+        expect(response_code).to eq(403)
+      end
     end
   end
 end

--- a/spec/responses/stash_api/files_controller_spec.rb
+++ b/spec/responses/stash_api/files_controller_spec.rb
@@ -280,10 +280,10 @@ module StashApi
       it 'allows download by owner for unpublished but in Merritt' do
         @curation_activities[0][2].destroy!
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-                                          owner_id: @user1.id, owner_type: 'StashEngine::User')
+                                                                   owner_id: @user1.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
         response_code = get "/api/files/#{@files[0].first.id}/download", {}, default_json_headers
-                                                                                 .merge('Accept' => '*', 'Authorization' => "Bearer #{access_token}")
+          .merge('Accept' => '*', 'Authorization' => "Bearer #{access_token}")
         expect(response_code).to eq(200)
         expect(response.body).to eq('This file is awesome')
       end

--- a/spec/responses/stash_api/files_controller_spec.rb
+++ b/spec/responses/stash_api/files_controller_spec.rb
@@ -1,0 +1,187 @@
+require 'rails_helper'
+require 'uri'
+require_relative 'helpers'
+require 'fixtures/stash_api/metadata'
+require 'fixtures/stash_api/curation_metadata'
+require 'cgi'
+
+# rubocop:disable Metrics/BlockLength, Metrics/ModuleLength
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashApi
+  RSpec.describe FilesController, type: :request do
+
+    include Mocks::Ror
+    include Mocks::RSolr
+    include Mocks::Stripe
+    include Mocks::CurationActivity
+    include Mocks::Repository
+    include Mocks::UrlUpload
+
+    before(:all) do
+      @user = create(:user, role: 'superuser')
+      @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                                                owner_id: @user.id, owner_type: 'StashEngine::User')
+      setup_access_token(doorkeeper_application: @doorkeeper_application)
+    end
+
+    # set up some versions with different curation statuses (visibility)
+    before(:each) do
+      neuter_curation_callbacks!
+      mock_ror!
+
+      @tenant_ids = StashEngine::Tenant.all.map(&:tenant_id)
+
+      @user1 = create(:user, tenant_id: @tenant_ids.first, role: 'user')
+
+      @identifier = create(:identifier)
+
+      @resources = [create(:resource, user_id: @user1.id, tenant_id: @user1.tenant_id, identifier_id: @identifier.id),
+                    create(:resource, user_id: @user1.id, tenant_id: @user1.tenant_id, identifier_id: @identifier.id)]
+
+      @curation_activities = [[create(:curation_activity, resource: @resources[0], status: 'in_progress'),
+                               create(:curation_activity, resource: @resources[0], status: 'curation'),
+                               create(:curation_activity, resource: @resources[0], status: 'published')]]
+
+      @curation_activities << [create(:curation_activity, resource: @resources[1], status: 'in_progress')]
+
+      @resources[0].current_resource_state.update(resource_state: 'submitted')
+      @resources[1].current_resource_state.update(resource_state: 'in_progress')
+
+      # be sure versions are set correctly, because creating them manually like this doesn't ensure it
+      @resources[0].stash_version.update(version: 1)
+      @resources[1].stash_version.update(version: 2)
+      @file_path = Rails.root.join('spec/fixtures/http_responses/favicon.ico')
+      @mime_type = 'image/vnd.microsoft.icon'
+    end
+
+
+    # working with files
+    describe '#update' do
+      it 'will add a file upload to the server and add metadata' do
+        response_code = put "/api/datasets/#{CGI.escape(@identifier.to_s)}/files/#{CGI.escape(::File.basename(@file_path))}",
+                            IO.read(@file_path), default_authenticated_headers.merge('Content-Type' => @mime_type)
+        expect(response_code).to eq(201)
+        hsh = response_body_hash
+        expect(hsh['_links']['self']['href']).not_to be_nil
+        expect(hsh['path']).to eq(::File.basename(@file_path))
+        expect(hsh['size']).to eq(::File.size(@file_path))
+        expect(hsh['mimeType']).to eq(@mime_type)
+        expect(hsh['status']).to eq('created')
+        expect(hsh['digest']).to eq(Digest::MD5.hexdigest(::File.read(@file_path)))
+        expect(hsh['digestType']).to eq('md5')
+      end
+
+      it 'will not allow non-logged in to add a file' do
+        response_code = put "/api/datasets/#{CGI.escape(@identifier.to_s)}/files/#{CGI.escape(::File.basename(@file_path))}",
+                            IO.read(@file_path), default_json_headers.merge('Content-Type' => @mime_type)
+        expect(response_code).to eq(401)
+      end
+    end
+
+    describe '#show' do
+      before(:each) do
+        put "/api/datasets/#{CGI.escape(@identifier.to_s)}/files/#{CGI.escape(::File.basename(@file_path))}",
+            IO.read(@file_path), default_authenticated_headers.merge('Content-Type' => @mime_type)
+        hsh = response_body_hash
+        @the_path = hsh['_links']['self']['href'] # this is a little weird, may need fixing
+      end
+
+      it 'shows the file info for a file that exists (superuser)' do
+        response_code = get @the_path, {}, default_authenticated_headers
+        expect(response_code).to eq(200)
+        hsh = response_body_hash
+        expect(hsh['path']).to eq(::File.basename(@file_path))
+        expect(hsh['size']).to eq(::File.size(@file_path))
+        expect(hsh['mimeType']).to eq(@mime_type)
+        expect(hsh['status']).to eq('created')
+        expect(hsh['digest']).to eq(Digest::MD5.hexdigest(::File.read(@file_path)))
+        expect(hsh['digestType']).to eq('md5')
+      end
+
+      it "doesn't allow listing a file that should be hidden from the public" do
+        response_code = get @the_path, {}, default_json_headers
+        expect(response_code).to eq(404)
+      end
+
+      it "shows non-public files to the owner" do
+        @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                          owner_id: @user1.id, owner_type: 'StashEngine::User')
+        access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
+        response_code = get @the_path, {}, default_json_headers.merge(
+            'Content-Type' => 'application/json-patch+json', 'Authorization' => "Bearer #{access_token}")
+        expect(response_code).to eq(200)
+        # return message tested elsewhere already
+      end
+
+      it 'shows non-public files to an admin for the same tenant' do
+        @user1.update(role: 'admin')
+        @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                          owner_id: @user1.id, owner_type: 'StashEngine::User')
+        access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
+        response_code = get @the_path, {}, default_json_headers.merge(
+            'Content-Type' => 'application/json-patch+json', 'Authorization' => "Bearer #{access_token}")
+        expect(response_code).to eq(200)
+      end
+    end
+
+    describe '#index' do
+
+      before(:each) do
+        create_list(:file_upload, 25, resource_id: @resources[0].id)
+        create_list(:file_upload, 4, resource_id: @resources[1].id)
+      end
+
+      it 'shows an index of files for a public dataset version' do
+        response_code = get "/api/versions/#{@resources[0].id}/files", {}, default_authenticated_headers
+        hsh = response_body_hash
+        expect(response_code).to eq(200)
+        expect(hsh['total']).to eq(25)
+        item_hash = hsh['_embedded']['stash:files'].first
+        %w{path size mimeType status}.each do |i|
+          expect(item_hash[i]).not_to be_nil
+        end
+      end
+
+      it 'shows an index of files for a private dataset version to the superuser' do
+        # check the superuser
+        response_code = get "/api/versions/#{@resources[1].id}/files", {}, default_authenticated_headers
+        hsh = response_body_hash
+        expect(response_code).to eq(200)
+        expect(hsh['total']).to eq(4)
+      end
+
+      it 'shows an index of files for a private dataset version to the owner' do
+        @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                          owner_id: @user1.id, owner_type: 'StashEngine::User')
+        access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
+        response_code = get "/api/versions/#{@resources[1].id}/files", {}, default_json_headers.merge(
+            'Authorization' => "Bearer #{access_token}")
+        hsh = response_body_hash
+        expect(response_code).to eq(200)
+        expect(hsh['total']).to eq(4)
+      end
+
+      it 'shows an index of files for a private dataset version to the admin' do
+        @user.update(role: 'admin', tenant_id: @tenant_ids.first)
+        response_code = get "/api/versions/#{@resources[1].id}/files", {}, default_authenticated_headers
+        hsh = response_body_hash
+        expect(response_code).to eq(200)
+        expect(hsh['total']).to eq(4)
+      end
+
+      it "doesn't show private version's list of file to non-user" do
+        response_code = get "/api/versions/#{@resources[1].id}/files", {}, default_json_headers
+        hsh = response_body_hash
+        expect(response_code).to eq(404)
+      end
+
+      it "doesn't show private versions list of files to a random user" do
+        @user.update(role: 'user', tenant_id: @tenant_ids.first)
+        response_code = get "/api/versions/#{@resources[1].id}/files", {}, default_authenticated_headers
+        hsh = response_body_hash
+        expect(response_code).to eq(404)
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength, Metrics/ModuleLength

--- a/spec/responses/stash_api/urls_controller_spec.rb
+++ b/spec/responses/stash_api/urls_controller_spec.rb
@@ -64,7 +64,7 @@ module StashApi
     # Test creation of new manifest URL by getting basic info from a HEAD request and populating it. Just a basic test.
     # There are workarounds in the URL discovering library for Google drive and doing GET requests and some other stuff,
     # but that really belongs being tested at that component level and probably not here.
-    describe '#index' do
+    describe '#create' do
       it 'will retrive, validate and fill in info from a URL from the internet by HEAD request' do
         mock_github_head_request!
         test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'


### PR DESCRIPTION
For this ticket in both stash and dryad repos.  Most of the work was testing.  https://github.com/CDL-Dryad/dryad-product-roadmap/issues/365

 Get the list of files for a version
  Get file metadata for a file
  Upload (stage) a file on the server for submission
  Remove staged file from a version
  Download an individual file.