### PR TITLE
Updated app config to force UTC timezones

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,8 @@ module Dash2
     config.active_record.raise_in_transactional_callbacks = true
     config.generators.javascript_engine = :js
     config.autoload_paths << Rails.root.join("lib")
+
+    config.time_zone = "UTC"
+    config.active_record.default_timezone = :utc
   end
 end


### PR DESCRIPTION
Update to the main `application.rb` file to set the default timezone and ensure that ActiveRecord are using UTC