### PR TITLE
Configuration updates for production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,13 +82,15 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   #this is obnoxious because the initializers haven't run yet, so have to duplicate code to read config
-  ac = YAML.load_file(File.join(Rails.root, 'config', 'app_config.yml'))[Rails.env]
+  # this will interpret any ERB in the yaml file first before bringing in
+  ac = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', 'app_config.yml'))).result)[Rails.env]
+
   unless ac['page_error_email'].blank?
     Rails.application.config.middleware.use ExceptionNotification::Rack,
       :email => {
           # :deliver_with => :deliver, # Rails >= 4.2.1 do not need this option since it defaults to :deliver_now
-          :email_prefix => "[Dash Exception]",
-          :sender_address => %{"Dash Notifier" <no-reply-dash2@ucop.edu>},
+          :email_prefix => "[Dryad Exception]",
+          :sender_address => %{"Dryad Notifier" <no-reply-dryad@dryad-prd.cdlib.org>},
           :exception_recipients => ac['page_error_email']
       },
       :error_grouping => true,

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -7,7 +7,8 @@ defaults: &DEFAULTS
   ezid:
     host: ezid.cdlib.org
     port: 443
-  default_tenant: dryad
+  google_maps_api_key: <add_key_here>
+  contact_us_uri: http://www.cdlib.org/services/uc3/contact.html
   orcid:
     site: https://sandbox.orcid.org/
     authorize_url: https://sandbox.orcid.org/oauth/authorize
@@ -17,8 +18,10 @@ defaults: &DEFAULTS
     member: true
     sandbox: true
     api: https://api.sandbox.orcid.org
+  submission_error_email: [my.fun.submission.error.emails@example.com]
   submission_bc_emails: [""]
   contact_email: ["changeme@example.org"]
+  default_tenant: dryad
   old_dryad_access_token: <REPLACE-ME>
   old_dryad_url: https://api.datadryad.org
   payments:
@@ -129,14 +132,9 @@ defaults: &DEFAULTS
 
 development: &DEVELOPMENT
   <<: *DEFAULTS
-  ezid:
-    host: ezid.cdlib.org
-    port: 443
-  google_maps_api_key: <add_key_here>
-  contact_us_uri: http://www.cdlib.org/services/uc3/contact.html
+  submission_error_email: [emailme@example.org]
   shib_sp_host: <fill-me-in>
   page_error_email: ~
-  submission_error_email: [emailme@example.org]
   feedback_email_from: no-reply@example.org
   collection_uri: http://uc3-mrtsword-dev.cdlib.org:39001/mrtsword/
   google_analytics_id: <fill-me-in>
@@ -146,6 +144,7 @@ local:
 
 test:
   <<: *DEFAULTS
+  google_maps_api_key: ~
   repository: Mocks::Repository::Repository
   contact_email: ["contact1@example.edu", "contact2@example.edu"]
   default_tenant: localhost


### PR DESCRIPTION
This is a triple-whammy PR with changes to all three repositories (dryad, stash and dryad-config).

Partially for https://github.com/CDL-Dryad/dryad-product-roadmap/issues/348 and https://github.com/CDL-Dryad/dryad-product-roadmap/issues/399 .

What it does:
- Went through all configs to try and make them consistent and also be sure the required info is filled in for general configs and for tenants for production.
- I had to modify loading of the exception notifier in production to parse tags in the Yaml since we have some.  This is why mark couldn't get it to install.  Made stage consistent.
- Rearranged the example to be consistent with our real one in order and other ways.
- Added fix for nil error in latest SOLR datasets, return an empty string if the item is falsey.
- Re-enabled bcc for campus contacts for dataset state changes (campus contacts are emails that can be added to the config).
- Lots of minor tweaks for production environments.  Mostly to be sure they are setup for correct Merritt collections or else for correct DOI registration/shoulders.
