### PR TITLE
added redirects for old dryad landing pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,19 @@ Rails.application.routes.draw do
   get 'widgets/bannerForPub' => 'stash_engine/widgets#banner_for_pub'
   get 'widgets/dataPackageForPub' => 'stash_engine/widgets#data_package_for_pub'
 
+  # Routing to redirect old Dryad URLs to their correct locations in this system
+  get '/pages/dryadlab', to: redirect('http://wiki.datadryad.org/Category:DryadLab')
+  get '/pages/faq', to: redirect('stash/faq')
+  get '/pages/jdap', to: redirect('http://wiki.datadryad.org/Joint_Data_Archiving_Policy_(JDAP)')
+  get '/pages/membershipOverview', to: redirect('stash/our_community')
+  get '/pages/organization', to: redirect('stash/our_mission')
+  get '/pages/policies', to: redirect('stash/terms')
+  get '/pages/publicationBlackout', to: redirect('stash/submission_process#citation')
+  get '/pages/searching', to: redirect('search')
+  get '/themes/Dryad/images/:image', to: redirect('/images/%{image}')
+  get '/themes/Dryad/images/dryadLogo.png', to: redirect('/images/logo_dryad.png')
+  get '/themes/Mirage/docs/:doc', to: redirect('/docs/%{doc}.%{format}')
+
   # Routing to redirect old Dryad landing pages to the correct location
   # Dataset:            https://datadryad.org/resource/doi:10.5061/dryad.kq201
   # Version of Dataset: https://datadryad.org/resource/doi:10.5061/dryad.kq201.2
@@ -105,18 +118,5 @@ Rails.application.routes.draw do
     doi_prefix: /[^\/]+/,
     doi_suffix: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,
     to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}?latest=true" }
-
-  # Routing to redirect old Dryad URLs to their correct locations in this system
-  get '/pages/dryadlab', to: redirect('http://wiki.datadryad.org/Category:DryadLab')
-  get '/pages/faq', to: redirect('stash/faq')
-  get '/pages/jdap', to: redirect('http://wiki.datadryad.org/Joint_Data_Archiving_Policy_(JDAP)')
-  get '/pages/membershipOverview', to: redirect('stash/our_community')
-  get '/pages/organization', to: redirect('stash/our_mission')
-  get '/pages/policies', to: redirect('stash/terms')
-  get '/pages/publicationBlackout', to: redirect('stash/submission_process#citation')
-  get '/pages/searching', to: redirect('search')
-  get '/themes/Dryad/images/:image', to: redirect('/images/%{image}')
-  get '/themes/Dryad/images/dryadLogo.png', to: redirect('/images/logo_dryad.png')
-  get '/themes/Mirage/docs/:doc', to: redirect('/docs/%{doc}.%{format}')
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,7 @@ Rails.application.routes.draw do
   get '/resource/:doi_prefix/:doi_suffix',
     doi_prefix: /[^\/]+/,
     doi_suffix: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,
-    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}?latest=true" }
+    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}" }
   # File within a Dataset:            https://datadryad.org/resource/doi:10.5061/dryad.kq201/3
   # Version of File within a Dataset: https://datadryad.org/resource/doi:10.5061/dryad.kq201/3.1
   # File within a Version:            https://datadryad.org/resource/doi:10.5061/dryad.kq201.2/3
@@ -117,6 +117,6 @@ Rails.application.routes.draw do
   get '/resource/:doi_prefix/:doi_suffix*file',
     doi_prefix: /[^\/]+/,
     doi_suffix: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,
-    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}?latest=true" }
+    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}" }
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,22 @@ Rails.application.routes.draw do
   get 'widgets/bannerForPub' => 'stash_engine/widgets#banner_for_pub'
   get 'widgets/dataPackageForPub' => 'stash_engine/widgets#data_package_for_pub'
 
+  # Routing to redirect old Dryad landing pages to the correct location
+  # Dataset:            https://datadryad.org/resource/doi:10.5061/dryad.kq201
+  # Version of Dataset: https://datadryad.org/resource/doi:10.5061/dryad.kq201.2
+  get '/resource/:doi_prefix/:doi_suffix',
+    doi_prefix: /[^\/]+/,
+    doi_suffix: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,
+    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}?latest=true" }
+  # File within a Dataset:            https://datadryad.org/resource/doi:10.5061/dryad.kq201/3
+  # Version of File within a Dataset: https://datadryad.org/resource/doi:10.5061/dryad.kq201/3.1
+  # File within a Version:            https://datadryad.org/resource/doi:10.5061/dryad.kq201.2/3
+  # Version of File within a Version: https://datadryad.org/resource/doi:10.5061/dryad.kq201.2/3.1
+  get '/resource/:doi_prefix/:doi_suffix*file',
+    doi_prefix: /[^\/]+/,
+    doi_suffix: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,
+    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}?latest=true" }
+
   # Routing to redirect old Dryad URLs to their correct locations in this system
   get '/pages/dryadlab', to: redirect('http://wiki.datadryad.org/Category:DryadLab')
   get '/pages/faq', to: redirect('stash/faq')
@@ -99,7 +115,7 @@ Rails.application.routes.draw do
   get '/pages/policies', to: redirect('stash/terms')
   get '/pages/publicationBlackout', to: redirect('stash/submission_process#citation')
   get '/pages/searching', to: redirect('search')
-  get '/themes/Dryad/images/:', to: redirect('/images/%{image}')
+  get '/themes/Dryad/images/:image', to: redirect('/images/%{image}')
   get '/themes/Dryad/images/dryadLogo.png', to: redirect('/images/logo_dryad.png')
   get '/themes/Mirage/docs/:doc', to: redirect('/docs/%{doc}.%{format}')
 

--- a/spec/factories/stash_datacite/related_identifiers.rb
+++ b/spec/factories/stash_datacite/related_identifiers.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
 
     trait :publication_doi do
-      related_identifier      { Faker::Pid.doi || Faker::Number.number(8) }
+      related_identifier      { Faker::Pid.doi }
       related_identifier_type { 'doi' }
       relation_type           { 'issupplementto' }
     end

--- a/spec/factories/stash_datacite/related_identifiers.rb
+++ b/spec/factories/stash_datacite/related_identifiers.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
 
     trait :publication_doi do
-      related_identifier      { Faker::Pid.doi }
+      related_identifier      { Faker::Pid.doi || Faker::Number.number(8) }
       related_identifier_type { 'doi' }
       relation_type           { 'issupplementto' }
     end


### PR DESCRIPTION
Added redirects for the old dryad landing pages. All requests for `/resource/[:doc].[:version]/[:file].[:version]` will be redirected to the main dataset landing page. 

For example:
- Dataset: https://dryad-dev.cdlib.org/resource/doi:10.5061/dryad.kq201
- Version of Dataset: https://dryad-dev.cdlib.org/resource/doi:10.5061/dryad.kq201.2
- File within a Dataset: https://dryad-dev.cdlib.org/resource/doi:10.5061/dryad.kq201/3
- Version of File within a Dataset: https://dryad-dev.cdlib.org/resource/doi:10.5061/dryad.kq201/3.1
- File within a Version of a Dataset: https://dryad-dev.cdlib.org/resource/doi:10.5061/dryad.kq201.2/3
- Version of File within a Version of a Dataset: https://dryad-dev.cdlib.org/resource/doi:10.5061/dryad.kq201.2/3.1

Will all be redirected to: https://dryad-dev.cdlib.org/stash/dataset/doi:10.5061/dryad.kq201?latest=true