### PR TITLE
fixed issue with mysqldump rake task

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -80,8 +80,8 @@ namespace :dev_ops do
   task backup: :environment do
     directory = '/apps/dryad/apps/ui/shared/cron/backups'
     FileUtils.mkdir directory unless File.exist?(directory)
-    db = YAML.safe_load(File.open(File.join(Rails.root, 'config', 'database.yml')))[Rails.env]
-    file = File.join(directory, "#{Rails.env}_#{Time.now}.sql")
+    db = YAML.load(File.open(File.join(Rails.root, 'config', 'database.yml')))[Rails.env]
+    file = File.join(directory, "#{Rails.env}_#{Time.now.strftime('%H_%M')}.sql")
     p command = 'mysqldump --opt --skip-add-locks --single-transaction --no-create-db ' \
                 "-h #{db['host']} -u #{db['username']} -p#{db['password']} #{db['database']} | gzip > #{file}.gz"
     exec command

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -80,7 +80,10 @@ namespace :dev_ops do
   task backup: :environment do
     directory = '/apps/dryad/apps/ui/shared/cron/backups'
     FileUtils.mkdir directory unless File.exist?(directory)
+    # YAML.safe_load is preferred by rubocop but it causes the read to fail on `unknown alias 'defaul'`
+    # rubocop:disable Security/YAMLLoad
     db = YAML.load(File.open(File.join(Rails.root, 'config', 'database.yml')))[Rails.env]
+    # rubocop:enable Security/YAMLLoad
     file = File.join(directory, "#{Rails.env}_#{Time.now.strftime('%H_%M')}.sql")
     p command = 'mysqldump --opt --skip-add-locks --single-transaction --no-create-db ' \
                 "-h #{db['host']} -u #{db['username']} -p#{db['password']} #{db['database']} | gzip > #{file}.gz"


### PR DESCRIPTION
mysqldump task was having issues using `safe_load` when opening the database yams file and also was creating file names that included the date so would not overwrite themselves each day.