### PR TITLE
Fixing misc settings (not search words)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'stripe'
 # ############################################################
 # Development and testing
 
-group :development do
+group :development, :local_dev do
   gem 'colorize', '~> 0.8'
   gem 'web-console', '~> 2.0'
   # gem 'httplog', not needed always, but good for troubleshooting HTTP requests to outside http services from the app
@@ -98,7 +98,7 @@ group :test do
   gem 'webmock'
 end
 
-group :development, :test do
+group :development, :test, :local_dev do
   gem 'binding_of_caller'
   # Ruby fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
   gem 'byebug'

--- a/config/environments/local_dev.rb
+++ b/config/environments/local_dev.rb
@@ -43,6 +43,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # local_dev is also development so let development stuff work here
+  config.web_console.development_only = false
+
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,6 +101,6 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
 
-  config.action_mailer.default_url_options = { host: 'datadryad.org' }
-  Rails.application.default_url_options = { host: 'datadryad.org' }
+  config.action_mailer.default_url_options = { host: 'dryadx2-prd.cdlib.org' }
+  Rails.application.default_url_options = { host: 'dryadx2-prd.cdlib.org' }
 end


### PR DESCRIPTION
The local_dev environment (with automatic class reloading for local development) needed some settings for byebug to work and some other things.

Updating the production domain name to our pre-production one until we begin using datadryad.org since I think this will fix some of the orcid/shibboleth login issues for now.