### PR TITLE
SOLR changes for author institutions and API path now /api/v2

### DIFF
--- a/app/views/layouts/_submission_process.html.md
+++ b/app/views/layouts/_submission_process.html.md
@@ -10,7 +10,7 @@
 <li><strong>When preparing your complete version of a dataset, remember to collate all relevant explantory documents and metadata</strong>. This includes relevant documentation necessary for the re-use and replication of your dataset (e.g., readme.txt files, formal metadata records, or other critical information)</li>
 </ul>
 
-<p>Dryad has a REST API that allows for download and submission of data. Check out our <a href="https://dryad-stg.cdlib.org/api/docs/">documentation</a> as well as our <a href="https://github.com/CDL-Dryad/dryad/blob/master/stash_api/basic_submission.md">How-To Guide</a></p>
+<p>Dryad has a REST API that allows for download and submission of data. Check out our <a href="https://dryad-stg.cdlib.org/api/v2/docs/">documentation</a> as well as our <a href="https://github.com/CDL-Dryad/dryad/blob/master/stash_api/basic_submission.md">How-To Guide</a></p>
 
 <p>If you need further assistance, consult our <a href="<%= stash_url_helpers.faq_path %>">FAQ</a> or contact us at <a href=mailto:help@datadryad.org>help@datadryad.org</a>. Log in and go to "My Datasets" to begin your data submission now!</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
 
   mount StashEngine::Engine, at: APP_CONFIG.stash_mount
   mount StashDatacite::Engine, at: '/stash_datacite'
-  mount StashApi::Engine, at: '/api'
+  mount StashApi::Engine, at: '/api/v2'
 
   # we have to do this to make the geoblacklight routes come before catchall
   # http://blog.arkency.com/2015/02/how-to-split-routes-dot-rb-into-smaller-parts/

--- a/config/solr_config/schema.xml
+++ b/config/solr_config/schema.xml
@@ -188,6 +188,10 @@
   <!-- briley 06/03/2019 - fields to store the publication that cites the dataset -->
   <copyField source="dryad_related_publication_name_s" dest="dryad_related_publication_name_ti" maxChars="100"/>
   <copyField source="dryad_related_publication_id_s" dest="dryad_related_publication_id_ti" maxChars="100"/>
+  <!-- sfisher 08/22/2019 - fields to store the affiliation of authors -->
+  <copyField source="dryad_author_affiliation_name_sm" dest="dryad_author_affiliation_name_tmi" maxChars="1000"/>
+  <copyField source="dryad_author_affiliation_id_sm" dest="dryad_author_affiliation_id_tmi" maxChars="100"/>
+
 
   <!-- core text search -->
   <copyField source="*_ti"               dest="text" />

--- a/config/solr_config/solrconfig.xml
+++ b/config/solr_config/solrconfig.xml
@@ -131,6 +131,7 @@
         layer_slug_ti^10
         dc_identifier_ti^10
         dryad_related_publication_id_ti^11
+        dryad_author_affiliation_id_tmi^12
       </str>
       <!-- briley 06/03/2019 - field to store the publication id that cites the dataset -->
       <str name="pf"><!-- phrase boost within result set -->
@@ -149,6 +150,7 @@
         layer_slug_ti^10
         dc_identifier_ti^10
         dryad_related_publication_id_ti^11
+        dryad_author_affiliation_id_tmi^12
       </str>
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>
@@ -166,6 +168,8 @@
       <str name="facet.field">solr_year_i</str>
       <!-- briley 06/03/2019 - provide a facet for the publication that cites the dataset -->
       <str name="facet.field">dryad_related_publication_name_s</str>
+      <!-- sfisher 08/22/2019 - provide a facet for author affiliation(s) -->
+      <str name="facet.field">dryad_author_affiliation_name_sm</str>
 
       <str name="spellcheck">true</str>
     </lst>

--- a/documentation/api_submission.md
+++ b/documentation/api_submission.md
@@ -1,7 +1,7 @@
 # Doing a basic submission and an version update with the Dryad API
 The Dryad API now enables submission.  For authentication, it uses an OAuth2 client credentials grant (see [A Guide To OAuth 2.0 Grants](https://alexbilbie.com/guide-to-oauth-2-grants/)).
 
-This document gives practical information for working with the API in order to submit a dataset and [fuller API documentation is available](https://dash.ucop.edu/api/docs/index.html).
+This document gives practical information for working with the API in order to submit a dataset and [fuller API documentation is available](https://datadryad.org/api/v2/docs/index.html).
 
 ## Log in to Dryad and request a an application id and secret
 
@@ -39,7 +39,7 @@ token = JSON.parse(response)['access_token']
 Now make sure you can use your key to access secured areas of the API.  Test with some code like the following.
 
 ```bash
-curl -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -X GET https://<domain>/api/test
+curl -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -X GET https://<domain>/api/v2/test
 ```
 
 or
@@ -48,7 +48,7 @@ or
 # this Ruby example continues from the section above and assumes the variables above are already set
 headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{token}" }
 
-resp = RestClient.get "https://#{domain_name}/api/test", headers
+resp = RestClient.get "https://#{domain_name}/api/v2/test", headers
 
 j = JSON.parse(resp)
 ```
@@ -66,7 +66,7 @@ After a successful dataset POST, you should see the dataset created with your me
 For the cURL example, create a file called my_metadata.json that contains your json for the descriptive metadata to send with cURL.
 
 ```bash
-curl --data "@my_metadata.json" -i -X POST https://<domain-name>/api/datasets -H "Authorization: Bearer <token>" -H "Content-Type: application/json"
+curl --data "@my_metadata.json" -i -X POST https://<domain-name>/api/v2/datasets -H "Authorization: Bearer <token>" -H "Content-Type: application/json"
 ```
 Or
 
@@ -85,7 +85,7 @@ metadata_hash =
    	 ],
     "abstract": "Cyberneticists agree that concurrent models are an interesting new topic in the field of machine learning, and security experts concur."
   }
-resp = RestClient.post "https://#{domain_name}/api/datasets", metadata_hash.to_json, headers
+resp = RestClient.post "https://#{domain_name}/api/v2/datasets", metadata_hash.to_json, headers
 # you should see a 201 response here
 
 # to see information about the dataset created
@@ -119,10 +119,10 @@ You may upload multiple files for your dataset. Only all direct file uploads or 
 
 Find a file on your file system to upload, get its path and determine its Content-Type.  You would send it to the server like the example below by changing the file\_path and content\_type values.
 
-For direct file uploads, do a PUT to {{url-domain-name}}/api/datasets/{{doi_encoded}}/files/{{filename-encoded}} and the body being sent would be the binary file.  Set the HTTP "Content-Description" header to add a short description.  Set the HTTP Content-Type appropriately for the file type (for example image/jpeg).
+For direct file uploads, do a PUT to {{url-domain-name}}/api/v2/datasets/{{doi_encoded}}/files/{{filename-encoded}} and the body being sent would be the binary file.  Set the HTTP "Content-Description" header to add a short description.  Set the HTTP Content-Type appropriately for the file type (for example image/jpeg).
 
 ```bash
-curl --data-binary "@</path/to/my/file>" -i -X PUT "https://<domain-name>/api/datasets/<encoded-doi>/files/<encoded-file-name>" -H "Authorization: Bearer <token>" -H "Content-Type: <mime-type>" -H "Accept: application/json"
+curl --data-binary "@</path/to/my/file>" -i -X PUT "https://<domain-name>/api/v2/datasets/<encoded-doi>/files/<encoded-file-name>" -H "Authorization: Bearer <token>" -H "Content-Type: <mime-type>" -H "Accept: application/json"
 ```
 
 Or
@@ -142,7 +142,7 @@ file_name = URI.escape(File.basename(file_path))
 content_type = 'image/gif'
 
 resp = RestClient.put(
-  "https://#{domain_name}/api/datasets/#{doi_encoded}/files/#{file_name}",
+  "https://#{domain_name}/api/v2/datasets/#{doi_encoded}/files/#{file_name}",
   File.read(file_path),
   headers.merge({'Content-Type' => content_type})
 )
@@ -154,11 +154,11 @@ return_hash = JSON.parse(resp)
 ```
 
 After a file upload you will get a digest and digestType back in the JSON.  You can check this against your local file to be certain it was uploaded correctly if you wish.
-The other method is adding by URL.  You can do a POST to {{url-domain-name}}/api/datasets/{{doi_encoded}}/urls with json something like the following:
+The other method is adding by URL.  You can do a POST to {{url-domain-name}}/api/v2/datasets/{{doi_encoded}}/urls with json something like the following:
 
 ### Upload by URL reference
 
-To upload a file that is referenced by URL, do a POST to `{{url-domain-name}}/api/datasets/{{doi_encoded}}/urls` with json something like the following:
+To upload a file that is referenced by URL, do a POST to `{{url-domain-name}}/api/v2/datasets/{{doi_encoded}}/urls` with json something like the following:
 
 ```
 {
@@ -183,7 +183,7 @@ This will add entries to the database with the information you specify.  Only th
 
 After adding the descriptive metadata and any files, you're ready to publish your dataset.
 
-Publication is accomplished by sending a PATCH request to /api/datasets/&lt;encoded-doi&gt; with some json patch information that tells the server to try and set the /versionStatus value to 'submitted' like below:
+Publication is accomplished by sending a PATCH request to /api/v2/datasets/&lt;encoded-doi&gt; with some json patch information that tells the server to try and set the /versionStatus value to 'submitted' like below:
 
 ```json
 [
@@ -195,7 +195,7 @@ You also need to set the Content-Type header to 'application/json-patch+json'
 For the cURL example, please save a file called my_patch.json with the patch content shown above.
 
 ```bash
-curl --data "@my_patch.json" -i -X PATCH "https://<domain-name>/api/datasets/<encoded-doi>" -H "Authorization: Bearer <token>" -H "Content-Type: application/json-patch+json" -H "Accept: application/json"
+curl --data "@my_patch.json" -i -X PATCH "https://<domain-name>/api/v2/datasets/<encoded-doi>" -H "Authorization: Bearer <token>" -H "Content-Type: application/json-patch+json" -H "Accept: application/json"
 ```
 Or
 
@@ -204,14 +204,14 @@ Or
 body = [ { "op": "replace", "path": "/versionStatus", "value": "submitted" } ].to_json
 
 resp = RestClient.patch(
-  "https://#{domain_name}/api/datasets/#{doi_encoded}",
+  "https://#{domain_name}/api/v2/datasets/#{doi_encoded}",
   body,
   headers.merge({'Content-Type' =>  'application/json-patch+json'})
 )
 
 # A successful response will be a 202 and you should receive a json response
 # with information about the submission.  You may continue to do GET requests
-# on the dataset /api/datasets/<encoded-doi> to see the status changes until
+# on the dataset /api/v2/datasets/<encoded-doi> to see the status changes until
 # a successful ingest which will be 'submitted'.
 
 return_hash = JSON.parse(resp)
@@ -303,7 +303,7 @@ To modify your dataset you'll do a PUT request to the /datasets/<encoded-doi> UR
 ```ruby
 # this example continues the ones from above and asumes you already have variables defined
 
-resp = RestClient.put "https://#{domain_name}/api/datasets/#{doi_encoded}", metadata_hash.to_json, headers
+resp = RestClient.put "https://#{domain_name}/api/v2/datasets/#{doi_encoded}", metadata_hash.to_json, headers
 # You will see a 200 response code if all is well.
 ```
 

--- a/documentation/documentation_dump.md
+++ b/documentation/documentation_dump.md
@@ -32,7 +32,7 @@ Our demo instance of Dryad is available at [https://dashdemo.ucop.edu](https://d
 
 * A basic generalized introduction to Dryad's Dash is available at [https://dash.ucop.edu/stash/about](https://dash.ucop.edu/stash/about) .
 
-* API documentation: [https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md](https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md) and [https://dash.ucop.edu/api/docs/](https://dash.ucop.edu/api/docs/) 
+* API documentation: [https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md](https://github.com/CDLUC3/stash/blob/master/stash_api/basic_submission.md) and [https://datadryad.org/api/v2/docs/](https://dash.ucop.edu/api/v2/docs/)
 
 * A database [Entity-Relationship diagram](other_files/dash_er_2018-06.pdf).  
 

--- a/documentation/renew_api/retrying_expired.md
+++ b/documentation/renew_api/retrying_expired.md
@@ -65,7 +65,7 @@ rc = RetryClient.new(
           app_id: '<your-app-id>',
           secret: '<your-secret>',
           scheme_host_port: 'https://dryad-stg.cdlib.org')
-response = rc.retry(:get, '/api/test', {}) # params are HTTP method, path and extra headers
+response = rc.retry(:get, '/api/v2/test', {}) # params are HTTP method, path and extra headers
 => <RestClient::Response 200 "{\"message\":..."> # response object returned
 ```
 

--- a/documentation/test_submission/make_records.rb
+++ b/documentation/test_submission/make_records.rb
@@ -22,7 +22,7 @@ token = JSON.parse(response)['access_token']
 
 
 headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{token}" }
-resp = RestClient.get "#{domain_name}/api/test", headers
+resp = RestClient.get "#{domain_name}/api/v2/test", headers
 j = JSON.parse(resp)
 raise 'Invalid API connection' if j['user_id'].nil?
 puts "Logged in as #{j['user_id']}"
@@ -39,7 +39,7 @@ PATCH_SUBMISSION = [{ "op": "replace", "path": "/versionStatus", "value": "submi
 
   puts "  creating ds w/ title: #{metadata_hash[:title]}"
   # create new dataset with metadata
-  resp = RestClient.post "#{domain_name}/api/datasets", metadata_hash.to_json, headers
+  resp = RestClient.post "#{domain_name}/api/v2/datasets", metadata_hash.to_json, headers
   return_hash = JSON.parse(resp)
   doi = return_hash['identifier']
   doi_encoded = CGI.escape(doi)
@@ -56,7 +56,7 @@ PATCH_SUBMISSION = [{ "op": "replace", "path": "/versionStatus", "value": "submi
   puts "  uploading the file: #{fn}"
   content_type = 'text/plain'
   resp = RestClient.put(
-      "#{domain_name}/api/datasets/#{doi_encoded}/files/#{URI.escape(fn)}",
+      "#{domain_name}/api/v2/datasets/#{doi_encoded}/files/#{URI.escape(fn)}",
       File.read(fn),
       headers.merge({'Content-Type' => content_type})
   )
@@ -66,7 +66,7 @@ PATCH_SUBMISSION = [{ "op": "replace", "path": "/versionStatus", "value": "submi
   puts "  submitting the dataset"
   # submit the dataset to the storage repository
   resp = RestClient.patch(
-      "#{domain_name}/api/datasets/#{doi_encoded}",
+      "#{domain_name}/api/v2/datasets/#{doi_encoded}",
       PATCH_SUBMISSION,
       headers.merge({'Content-Type' =>  'application/json-patch+json'})
   )

--- a/dryad-config-example/settings.yml
+++ b/dryad-config-example/settings.yml
@@ -29,9 +29,10 @@ FIELDS:
   :TEMPORAL: 'dct_temporal_sm'
   :TITLE: 'dc_title_s'
   :RELATED_PUBLICATION_NAME: 'dryad_related_publication_name_s'
+  :AUTHOR_AFFILIATION_NAME: 'dryad_author_affiliation_name_sm'
 
 # Institution deployed at
-INSTITUTION: 'Stanford'
+INSTITUTION: 'Dryad'
 
 # Metadata shown in tool panel
 METADATA_SHOWN:

--- a/spec/responses/stash_api/general_controller_spec.rb
+++ b/spec/responses/stash_api/general_controller_spec.rb
@@ -16,14 +16,14 @@ module StashApi
 
     describe '#test' do
       it 'returns welcome message and authenticated user id for good token' do
-        post '/api/test', nil, default_authenticated_headers
+        post '/api/v2/test', nil, default_authenticated_headers
         hsh = response_body_hash
         expect(/Welcome application owner.+$/).to match(hsh[:message])
         expect(@user.id).to eql(hsh[:user_id])
       end
 
       it 'returns 401 unauthorized for non-authenticated user' do
-        response_code = post '/api/test', nil, default_json_headers
+        response_code = post '/api/v2/test', nil, default_json_headers
         expect(response_code).to eq(401) # unauthorized
         expect(/invalid_token/).to match(response.headers['WWW-Authenticate'])
       end
@@ -31,9 +31,9 @@ module StashApi
 
     describe '#index' do
       it 'has a HATEOAS link to the main entry into API, the datasets list' do
-        get '/api/', {}, default_json_headers
+        get '/api/v2/', {}, default_json_headers
         hsh = response_body_hash
-        expect(hsh['_links']['stash:datasets']['href']).to eql('/api/datasets')
+        expect(hsh['_links']['stash:datasets']['href']).to eql('/api/v2/datasets')
       end
     end
   end

--- a/spec/responses/stash_api/submission_queue_controller_spec.rb
+++ b/spec/responses/stash_api/submission_queue_controller_spec.rb
@@ -19,7 +19,7 @@ module StashApi
     # test queue length being returned
     describe '#length' do
       it 'returns JSON for queue length and executor queue length' do
-        get '/api/queue_length', {}, default_authenticated_headers
+        get '/api/v2/queue_length', {}, default_authenticated_headers
         output = JSON.parse(response.body).with_indifferent_access
         expect(output[:queue_length]).to be_a(Integer)
         expect(output[:executor_queue_length]).to be_a(Integer)

--- a/spec/responses/stash_api/urls_controller_spec.rb
+++ b/spec/responses/stash_api/urls_controller_spec.rb
@@ -68,7 +68,7 @@ module StashApi
       it 'will retrive, validate and fill in info from a URL from the internet by HEAD request' do
         mock_github_head_request!
         test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(201)
         hsh = response_body_hash
         expect(hsh['path']).to eq('favicon.ico')
@@ -79,7 +79,7 @@ module StashApi
       end
 
       it 'will take a manual population of url info without validation.  At your own risk and may barf on Merritt submission' do
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
         expect(response_code).to eq(201)
         hsh = response_body_hash
         FILE_HASH.keys.reject { |k| k == 'skipValidation' }.each do |key|
@@ -89,22 +89,22 @@ module StashApi
 
       it 'does not allow regular users to populate urls that are not validated' do
         @user.update(role: 'user')
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
         expect(response_code).to eq(401)
       end
 
       it "doesn't allow anonymous (not logged in) users to add urls" do
         mock_github_head_request!
         test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_json_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_json_headers
         expect(response_code).to eq(401)
       end
 
       it "doesn't allow adding the same URL multiple times" do
         mock_github_head_request!
         test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
-        post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
+        post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(403)
         expect(response_body_hash.key?('error')).to eq(true)
       end
@@ -112,14 +112,14 @@ module StashApi
       it 'disallows invalid-format urls' do
         mock_github_head_request!
         test_url = 'groogalona.fun/'
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(403)
       end
 
       it 'gives an error for non-validating urls (404)' do
         mock_github_bad_head_request!
         test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(403)
         expect(response_body_hash.key?('error')).to eq(true)
       end
@@ -129,7 +129,7 @@ module StashApi
         @resources[1].current_resource_state.update(resource_state: 'processing')
         mock_github_head_request!
         test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
-        response_code = post "/api/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(403)
         expect(response_body_hash.key?('error')).to eq(true)
       end

--- a/spec/responses/stash_api/versions_controller_spec.rb
+++ b/spec/responses/stash_api/versions_controller_spec.rb
@@ -54,7 +54,7 @@ module StashApi
     describe '#index' do
 
       it 'shows all versions to a superuser' do
-        response_code = get "/api/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_authenticated_headers
+        response_code = get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_authenticated_headers
         expect(response_code).to eq(200)
         expect(response_body_hash['total']).to eq(2)
         my_versions = response_body_hash['_embedded']['stash:versions']
@@ -69,7 +69,7 @@ module StashApi
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user1.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
-        response_code = get "/api/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers.merge(
+        response_code = get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers.merge(
           'Content-Type' => 'application/json-patch+json', 'Authorization' => "Bearer #{access_token}"
         )
 
@@ -88,7 +88,7 @@ module StashApi
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user2.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
-        response_code = get "/api/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers.merge(
+        response_code = get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers.merge(
           'Authorization' => "Bearer #{access_token}"
         )
 
@@ -102,7 +102,7 @@ module StashApi
       end
 
       it 'only shows only 1st version to non-logged-in user' do
-        response_code = get "/api/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers
+        response_code = get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers
 
         expect(response_code).to eq(200)
         expect(response_body_hash['total']).to eq(1)
@@ -118,7 +118,7 @@ module StashApi
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user2.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
-        response_code = get "/api/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers.merge(
+        response_code = get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/versions", {}, default_json_headers.merge(
           'Authorization' => "Bearer #{access_token}"
         )
 
@@ -134,7 +134,7 @@ module StashApi
     describe '#show' do
 
       it 'shows published versions to non-users' do
-        response_code = get "/api/versions/#{@resources[0].id}", {}, default_json_headers
+        response_code = get "/api/v2/versions/#{@resources[0].id}", {}, default_json_headers
         expect(response_code).to eq(200)
         h = response_body_hash
         expect(h['title']).to eq(@resources[0].title)
@@ -143,7 +143,7 @@ module StashApi
       end
 
       it "doesn't show unpublished version to non-user" do
-        response_code = get "/api/versions/#{@resources[1].id}", {}, default_json_headers
+        response_code = get "/api/v2/versions/#{@resources[1].id}", {}, default_json_headers
         expect(response_code).to eq(404)
       end
 
@@ -152,7 +152,7 @@ module StashApi
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user2.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
-        response_code = get "/api/versions/#{@resources[1].id}", {}, default_json_headers.merge(
+        response_code = get "/api/v2/versions/#{@resources[1].id}", {}, default_json_headers.merge(
           'Authorization' => "Bearer #{access_token}"
         )
         expect(response_code).to eq(404)
@@ -163,7 +163,7 @@ module StashApi
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user2.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
-        response_code = get "/api/versions/#{@resources[1].id}", {}, default_json_headers.merge(
+        response_code = get "/api/v2/versions/#{@resources[1].id}", {}, default_json_headers.merge(
           'Authorization' => "Bearer #{access_token}"
         )
         expect(response_code).to eq(200)
@@ -178,7 +178,7 @@ module StashApi
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user2.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
-        response_code = get "/api/versions/#{@resources[1].id}", {}, default_json_headers.merge(
+        response_code = get "/api/v2/versions/#{@resources[1].id}", {}, default_json_headers.merge(
           'Authorization' => "Bearer #{access_token}"
         )
         expect(response_code).to eq(200)
@@ -189,7 +189,7 @@ module StashApi
       end
 
       it 'returns 404 for non-existant resource, also' do
-        response_code = get "/api/versions/#{@resources[1].id + 100}", {}, default_json_headers
+        response_code = get "/api/v2/versions/#{@resources[1].id + 100}", {}, default_json_headers
         expect(response_code).to eq(404)
       end
 
@@ -218,7 +218,7 @@ module StashApi
       end
 
       it 'downloads a public version' do
-        response_code = get "/api/versions/#{@resources[0].id}/download", {}, {}
+        response_code = get "/api/v2/versions/#{@resources[0].id}/download", {}, {}
         expect(response_code).to eq(200)
         expect(response.body).to eq('This file is awesome')
       end
@@ -227,39 +227,39 @@ module StashApi
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user1.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)
-        response_code = get "/api/versions/#{@resources[1].id}/download", {},
+        response_code = get "/api/v2/versions/#{@resources[1].id}/download", {},
                             'Accept' => '*', 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{access_token}"
         expect(response_code).to eq(200)
         expect(response.body).to eq('This file is awesome')
       end
 
       it 'allows superuser to download private, but submitted to Merritt version' do
-        response_code = get "/api/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
+        response_code = get "/api/v2/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
         expect(response_code).to eq(200)
         expect(response.body).to eq('This file is awesome')
       end
 
       it 'disallows random user from downloading non-public, but submitted version' do
         @user.update(role: 'user')
-        response_code = get "/api/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
+        response_code = get "/api/v2/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
         expect(response_code).to eq(403)
       end
 
       it 'disallows nil user from downloading non-public, but submitted version' do
-        response_code = get "/api/versions/#{@resources[1].id}/download", {}, default_json_headers.merge('Accept' => '*')
+        response_code = get "/api/v2/versions/#{@resources[1].id}/download", {}, default_json_headers.merge('Accept' => '*')
         expect(response_code).to eq(403)
       end
 
       it 'allows admin to download private, but submitted to Merritt version' do
         @user.update(role: 'admin', tenant_id: @resources[1].tenant_id)
-        response_code = get "/api/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
+        response_code = get "/api/v2/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
         expect(response_code).to eq(200)
         expect(response.body).to eq('This file is awesome')
       end
 
       it "disallows download if it's not submitted to Merritt" do
         @resources[1].current_state = 'in_progress'
-        response_code = get "/api/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
+        response_code = get "/api/v2/versions/#{@resources[1].id}/download", {}, default_authenticated_headers.merge('Accept' => '*')
         expect(response_code).to eq(403)
       end
     end


### PR DESCRIPTION
Changes across all three repos.

Sorry, I probably should've created a different PR for the api stuff.  I thought it would be simple just changing the mount path but it turned into more.

This also has changes for the SOLR config in here.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/426