### PR TITLE
Turning off forcing SSL for application

### DIFF
--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.cache_classes = true
 
   # force_ssl causes infinite redirects, only do in apache or rails, not both
-  #config.force_ssl = true
+  # config.force_ssl = true
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.cache_classes = true
 
   # force_ssl causes infinite redirects, only do in apache or rails, not both
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.cache_classes = true
 
   # force_ssl causes infinite redirects, only do in apache or rails, not both
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
I turned off ssl for Mark and so we can get nagios tests working.  This is a small PR.