### PR TITLE
Curator editing defaults changed

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -110,7 +110,8 @@ RSpec.feature 'DatasetVersioning', type: :feature do
         it 'displays the proper information on the Admin page', js: true do
           within(:css, '.c-lined-table__row') do
             # Make sure the appropriate buttons are available
-            expect(page).not_to have_css('button[title="Edit Dataset"]')
+            # Curators want to edit everything unless it's in progress, so enjoy
+            expect(page).to have_css('button[title="Edit Dataset"]')
             expect(page).to have_css('button[aria-label="Update status"]')
 
             # Make sure the right text is shown


### PR DESCRIPTION
They want to edit whatever.  So as long as it's not technically infeasible (currently going through Merritt) or to lock out simultaneous edits by different people, then they can.

Updating a test for it to reflect it.