### PR TITLE
Adjusting error emails, passenger behavior

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -143,9 +143,12 @@ namespace :deploy do
         with rails_env: fetch(:rails_env) do
           execute "cd #{deploy_to}/current; bundle install --deployment"
           # see https://www.phusionpassenger.com/library/config/standalone/optimization/
+          # also looks like there is some memory leak and passenger grows ever bigger if it services too many requests
+          # https://www.phusionpassenger.com/library/config/standalone/reference/#--max-requests-max_requests
           execute "cd #{deploy_to}/current; bundle exec passenger start -d --environment #{fetch(:rails_env)} "\
               "--pid-file #{fetch(:passenger_pid)} -p #{fetch(:passenger_port)} "\
-              "--log-file #{fetch(:passenger_log)} --pool-idle-time 86400 --max-pool-size=#{fetch(:passenger_pool)}"
+              "--log-file #{fetch(:passenger_log)} --pool-idle-time 86400 --max-pool-size=#{fetch(:passenger_pool)} "\
+              "--max-requests=500"
         end
       end
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -145,7 +145,7 @@ namespace :deploy do
           # see https://www.phusionpassenger.com/library/config/standalone/optimization/
           execute "cd #{deploy_to}/current; bundle exec passenger start -d --environment #{fetch(:rails_env)} "\
               "--pid-file #{fetch(:passenger_pid)} -p #{fetch(:passenger_port)} "\
-              "--log-file #{fetch(:passenger_log)} --pool-idle-time 86400 --max-pool-size=10"
+              "--log-file #{fetch(:passenger_log)} --pool-idle-time 86400 --max-pool-size=#{fetch(:passenger_pool)}"
         end
       end
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -142,9 +142,10 @@ namespace :deploy do
       within current_path do
         with rails_env: fetch(:rails_env) do
           execute "cd #{deploy_to}/current; bundle install --deployment"
+          # see https://www.phusionpassenger.com/library/config/standalone/optimization/
           execute "cd #{deploy_to}/current; bundle exec passenger start -d --environment #{fetch(:rails_env)} "\
               "--pid-file #{fetch(:passenger_pid)} -p #{fetch(:passenger_port)} "\
-              "--log-file #{fetch(:passenger_log)} --pool-idle-time 86400"
+              "--log-file #{fetch(:passenger_log)} --pool-idle-time 86400 --max-pool-size=10"
         end
       end
     end

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -8,6 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, "development"
+set :passenger_pool, '6'
 
 # To override the default host, set $SERVER_HOSTS, e.g.
 #    $ SERVER_HOSTS='localhost1 localhost2' bundle exec cap development deploy

--- a/config/deploy/migration.rb
+++ b/config/deploy/migration.rb
@@ -8,6 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, 'migration'
+set :passenger_pool, '6'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'migration' }
 

--- a/config/deploy/prod1.rb
+++ b/config/deploy/prod1.rb
@@ -8,7 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, 'production'
-set :passenger_pool, '10'
+set :passenger_pool, '12'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 

--- a/config/deploy/prod1.rb
+++ b/config/deploy/prod1.rb
@@ -8,6 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, 'production'
+set :passenger_pool, '10'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 

--- a/config/deploy/prod2.rb
+++ b/config/deploy/prod2.rb
@@ -8,7 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, 'production'
-set :passenger_pool, '10'
+set :passenger_pool, '12'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 

--- a/config/deploy/prod2.rb
+++ b/config/deploy/prod2.rb
@@ -8,6 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, 'production'
+set :passenger_pool, '10'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 

--- a/config/deploy/stage1.rb
+++ b/config/deploy/stage1.rb
@@ -8,6 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, 'stage'
+set :passenger_pool, '6'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 

--- a/config/deploy/stage2.rb
+++ b/config/deploy/stage2.rb
@@ -8,6 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :rails_env, 'stage'
+set :passenger_pool, '6'
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
       },
       :error_grouping => true,
       :error_grouping_period => 3.hours,
-      :ignore_exceptions => ['ActionController::InvalidAuthenticityToken'] + ExceptionNotifier.ignored_exceptions,
+      :ignore_exceptions => ['ActionController::InvalidAuthenticityToken', 'ActionController::InvalidCrossOriginRequest'] + ExceptionNotifier.ignored_exceptions,
       :ignore_crawlers => %w{Googlebot bingbot}
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,9 @@ Rails.application.configure do
           :exception_recipients => ac['page_error_email']
       },
       :error_grouping => true,
-      :error_grouping_period => 3.hours
+      :error_grouping_period => 3.hours,
+      :ignore_exceptions => ['ActionController::InvalidAuthenticityToken'] + ExceptionNotifier.ignored_exceptions,
+      :ignore_crawlers => %w{Googlebot bingbot}
   end
 
   config.action_mailer.delivery_method = :sendmail

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -86,12 +86,14 @@ Rails.application.configure do
     Rails.application.config.middleware.use ExceptionNotification::Rack,
                                             :email => {
                                                 # :deliver_with => :deliver, # Rails >= 4.2.1 do not need this option since it defaults to :deliver_now
-                                                :email_prefix => "[Dryad Exception]",
+                                                :email_prefix => "[Drystg Exception]",
                                                 :sender_address => %{"Dryad Notifier" <no-reply-dryad@dryad-stg.cdlib.org>},
                                                 :exception_recipients => ac['page_error_email']
                                             },
                                             :error_grouping => true,
-                                            :error_grouping_period => 3.hours
+                                            :error_grouping_period => 3.hours,
+                                            :ignore_exceptions => ['ActionController::InvalidAuthenticityToken'] + ExceptionNotifier.ignored_exceptions,
+                                            :ignore_crawlers => %w{Googlebot bingbot}
   end
 
   config.action_mailer.delivery_method = :sendmail

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -92,7 +92,8 @@ Rails.application.configure do
                                             },
                                             :error_grouping => true,
                                             :error_grouping_period => 3.hours,
-                                            :ignore_exceptions => ['ActionController::InvalidAuthenticityToken'] + ExceptionNotifier.ignored_exceptions,
+                                            :ignore_exceptions => ['ActionController::InvalidAuthenticityToken',
+                                              'ActionController::InvalidCrossOriginRequest'] + ExceptionNotifier.ignored_exceptions,
                                             :ignore_crawlers => %w{Googlebot bingbot}
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,8 +83,9 @@ Rails.application.routes.draw do
 
   get 'xtf/search', :to => redirect { |params, request| "/search?#{request.params.to_query}" }
 
-  # this will route an item at the root of the site into the namespaced engine
-  get 'sitemap.xml' => "stash_engine/pages#sitemap", :format => "xml", :as => 'sitemap'
+  # This will route an item at the root of the site into the namespaced engine.
+  # However it is currently broken, so commented out until we fix it.
+  # get 'sitemap.xml' => "stash_engine/pages#sitemap", :format => "xml", :as => 'sitemap'
 
   # routing this into the engine since that is where we have all our models and curation state info which we need
   get 'widgets/bannerForPub' => 'stash_engine/widgets#banner_for_pub'


### PR DESCRIPTION
These are some settings to tweak things and save some of our sanity/time for more important things.

1. Stop emails for InvalidAuthenticityToken which are generally caused by robots that do not include the token since they are not actually browsing the site.

2. Comment out the sitemap.xml route in our routes.rb because it's broken and just sends us error emails that are annoying and useless and we know it is broken and there is a ticket somewhere.

3. Allow adjusting the Passenger --max-pool-size from our deploy startup.  It looks like each in the pool uses between 200 to 450-ish MB when I have looked.  The document at https://www.phusionpassenger.com/library/config/standalone/optimization/ suggests you can use about 75% of your memory.  For stage it's 4GB and for prod, each has 8GB.  I think we can probably up the max-pool to between 10-20 for passenger on each production server.  10 seems conservative and it's currently at 6.  The documents also suggest that it's more appropriate to increase the pool if the actions in your application have quite a bit of idle time within them such as waiting for database responses or waits on reading from files where some other process could take the unused CPU cycles in a context-switch while a process is waiting on something.

